### PR TITLE
Update HttpMsg.cc

### DIFF
--- a/src/core/HttpMsg.cc
+++ b/src/core/HttpMsg.cc
@@ -842,6 +842,7 @@ void HttpResp::Http(const std::string &url, int redirect_max, size_t size_limit)
 
     if(uri.query && uri.query[0])
     {
+        route.append("?");
         route.append(uri.query);
     }
 


### PR DESCRIPTION
解析后的uri.query不包含"?"，转发参数时需要重新加上。