### PR TITLE
test(cmake): make CTest registration reliable (#295)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,9 +33,17 @@ include_directories(
 link_directories(${WFREST_LIB_DIR} ${WORKFLOW_LIB_DIR})
 
 find_program(CMAKE_MEMORYCHECK_COMMAND valgrind)
-set(memcheck_command ${CMAKE_MEMORYCHECK_COMMAND} ${CMAKE_MEMORYCHECK_COMMAND_OPTIONS} --error-exitcode=1 --leak-check=full --show-leak-kinds=all)
+if (CMAKE_MEMORYCHECK_COMMAND)
+	set(memcheck_command
+		${CMAKE_MEMORYCHECK_COMMAND}
+		${CMAKE_MEMORYCHECK_COMMAND_OPTIONS}
+		--error-exitcode=1
+		--leak-check=full
+		--show-leak-kinds=all
+	)
+endif ()
 
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure)
 
 enable_testing()
 find_package(GTest REQUIRED)
@@ -65,12 +73,16 @@ foreach(src ${UNIT_TEST_LIST})
 	add_executable(${src} EXCLUDE_FROM_ALL ${src}.cc)
 	target_link_libraries(${src} ${WFREST_LIB} ${GTEST_LIB})
 	add_test(${src} ${src})
+	set_tests_properties(${src} PROPERTIES TIMEOUT 30)
 	add_dependencies(check ${src})
 endforeach()
 
-foreach(src ${UNIT_TEST_LIST})
-    add_test(${src}-memory-check ${memcheck_command} ./${src})
-endforeach()
+if (CMAKE_MEMORYCHECK_COMMAND)
+	foreach(src ${UNIT_TEST_LIST})
+		add_test(${src}-memory-check ${memcheck_command} ./${src})
+		set_tests_properties(${src}-memory-check PROPERTIES TIMEOUT 300)
+	endforeach()
+endif ()
 
 set(SERVER_UNIT_TEST_LIST
 	send_test
@@ -89,26 +101,44 @@ foreach(src ${SERVER_UNIT_TEST_LIST})
 	add_executable(server_${src} EXCLUDE_FROM_ALL ./HttpServer/${src}.cc)
 	target_link_libraries(server_${src} ${WFREST_LIB} ${GTEST_LIB})
 	add_test(server_${src} server_${src})
+	set_tests_properties(server_${src} PROPERTIES
+		RESOURCE_LOCK wfrest_test_server_ports
+		TIMEOUT 60
+	)
 	add_dependencies(check server_${src})
 endforeach()
 
+if (CMAKE_MEMORYCHECK_COMMAND)
+	foreach(src ${SERVER_UNIT_TEST_LIST})
+		add_test(server_${src}-memory-check ${memcheck_command} ./server_${src})
+		set_tests_properties(server_${src}-memory-check PROPERTIES
+			RESOURCE_LOCK wfrest_test_server_ports
+			TIMEOUT 300
+		)
+	endforeach()
+endif ()
 
-foreach(src ${SERVER_UNIT_TEST_LIST})
-    add_test(server_${src}-memory-check ${memcheck_command} ./server_${src})
-endforeach()
-
-set(TEST_LIST
+set(SMOKE_TEST_LIST
 	router_test
 	multi_part_test
 	StringPiece_feature
 	RouteTableNode_test
+)
+
+set(MANUAL_TEST_LIST
 	multi_verb_test
 )
 
-foreach(src ${TEST_LIST})
+foreach(src ${SMOKE_TEST_LIST})
+	add_executable(${src} EXCLUDE_FROM_ALL ${src}.cc)
+	target_link_libraries(${src} ${WFREST_LIB})
+	add_test(${src} ${src})
+	set_tests_properties(${src} PROPERTIES TIMEOUT 30)
+	add_dependencies(check ${src})
+endforeach()
+
+foreach(src ${MANUAL_TEST_LIST})
 	add_executable(${src} EXCLUDE_FROM_ALL ${src}.cc)
 	target_link_libraries(${src} ${WFREST_LIB})
 	add_dependencies(check ${src})
 endforeach()
-
-


### PR DESCRIPTION
## What changed

- Register Valgrind-backed entries only when `CMAKE_MEMORYCHECK_COMMAND` resolves to an executable.
- Separate four finite smoke tests from the interactive `multi_verb_test` and register the finite programs with CTest.
- Add 30-second unit/smoke and 60-second server functional timeouts.
- Add a shared `wfrest_test_server_ports` resource lock to fixed-port server suites.
- Give optional memory-check entries a 300-second timeout and the same server-port lock.
- Make the `check` target always print failed test output.

## Why

CTest previously reported invalid memory checks on machines without Valgrind, silently skipped four finite executables, could collide on ports 8887/8888 under `ctest -j`, and could wait forever after an asynchronous stall. The result was neither portable nor complete as a CI quality gate.

## Root cause

Test executables, CTest registration, optional tooling, and concurrency requirements were maintained as unrelated lists with no capability guard or execution properties.

## Impact

Production code and ABI are unchanged. The default functional suite grows from 22 to 26 tests and becomes valid without Valgrind. Hosts with Valgrind retain 22 memory-check entries. Interactive `multi_verb_test` is still built but intentionally not run.

## Validation

- `cmake -S test -B /tmp/wfrest-test-no-valgrind -DGTest_DIR=/usr/lib/x86_64-linux-gnu/cmake/GTest -DCMAKE_MEMORYCHECK_COMMAND=CMAKE_MEMORYCHECK_COMMAND-NOTFOUND`
- `cmake --build /tmp/wfrest-test-no-valgrind --target check --parallel 2` — 26/26 passed.
- `ctest --test-dir /tmp/wfrest-test-no-valgrind --parallel 8 --output-on-failure` — 26/26 passed; server suites were serialized by the resource lock.
- CTest JSON inspection — 26 entries, zero memory checks, zero missing timeouts, all 10 server entries share the resource lock.
- Capability-present configure using `/bin/true` as a deterministic command stub — 48 entries, 22 memory-check entries, zero `NOTFOUND` commands, all memory checks have 300-second timeouts.
- `git diff --check` — clean.

## Review structure

This is stacked on spec PR #296 so this PR contains only the implementation delta.

Issue: #295
Spec: #296