### PR TITLE
fix(util): handle empty and non-ASCII inputs safely (#298)

### DIFF
--- a/src/util/PathUtil.cc
+++ b/src/util/PathUtil.cc
@@ -43,6 +43,11 @@ std::string PathUtil::suffix(const std::string& filepath)
 
 std::string PathUtil::concat_path(const std::string &lhs, const std::string &rhs)
 {
+    if (lhs.empty())
+        return rhs;
+    if (rhs.empty())
+        return lhs;
+
     std::string res;
     // /v1/ /v2
     // remove one '/' -> /v1/v2

--- a/src/util/StrUtil.cc
+++ b/src/util/StrUtil.cc
@@ -1,5 +1,7 @@
 #include "StrUtil.h"
 
+#include <cctype>
+
 using namespace wfrest;
 
 const std::string wfrest::string_not_found = "";
@@ -7,6 +9,9 @@ const std::string StrUtil::k_pairs_ = R"({}[]()<>""''``)";
 
 StringPiece StrUtil::trim_pairs(const StringPiece &str, const char *pairs)
 {
+    if (str.size() < 2)
+        return str;
+
     const char *lhs = str.begin();
     const char *rhs = str.begin() + str.size() - 1;
     const char *p = pairs;
@@ -26,7 +31,7 @@ StringPiece StrUtil::trim_pairs(const StringPiece &str, const char *pairs)
 StringPiece StrUtil::ltrim(const StringPiece &str)
 {
     const char *lhs = str.begin();
-    while (lhs != str.end() && std::isspace(*lhs)) lhs++;
+    while (lhs != str.end() && std::isspace(static_cast<unsigned char>(*lhs))) lhs++;
     if (lhs == str.end()) return {};
     StringPiece res(str);
     res.remove_prefix(lhs - str.begin());
@@ -37,8 +42,8 @@ StringPiece StrUtil::rtrim(const StringPiece &str)
 {
     if (str.empty()) return str;
     const char *rhs = str.end() - 1;
-    while (rhs != str.begin() && std::isspace(*rhs)) rhs--;
-    if (rhs == str.begin() && std::isspace(*rhs)) return {};
+    while (rhs != str.begin() && std::isspace(static_cast<unsigned char>(*rhs))) rhs--;
+    if (rhs == str.begin() && std::isspace(static_cast<unsigned char>(*rhs))) return {};
     StringPiece res(str.begin(), rhs - str.begin() + 1);
     return res;
 }

--- a/test/PathUtil_unittest.cc
+++ b/test/PathUtil_unittest.cc
@@ -61,6 +61,11 @@ TEST(PathUtil, path_is_file)
 
 TEST(PathUtil, concat_path)
 {
+    EXPECT_EQ(PathUtil::concat_path("", ""), "");
+    EXPECT_EQ(PathUtil::concat_path("", "v3"), "v3");
+    EXPECT_EQ(PathUtil::concat_path("", "/v3"), "/v3");
+    EXPECT_EQ(PathUtil::concat_path("/v1/v2", ""), "/v1/v2");
+
     std::string concat1 = PathUtil::concat_path("/v1/v2", "v3");
     EXPECT_EQ(concat1, "/v1/v2/v3");
 

--- a/test/StrUtil_unittest.cc
+++ b/test/StrUtil_unittest.cc
@@ -63,10 +63,29 @@ TEST(StrUtil, trim)
 
 TEST(StrUtil, trim_pairs)
 {
+    StringPiece empty;
+    EXPECT_TRUE(StrUtil::trim_pairs(empty).empty());
+
+    StringPiece one_byte("\"");
+    EXPECT_EQ("\"", StrUtil::trim_pairs(one_byte, R"(""'')").as_string());
+
+    StringPiece identical_pair("a");
+    EXPECT_EQ("a", StrUtil::trim_pairs(identical_pair, "aa").as_string());
+
     StringPiece str1("\"name  name  address password\"");
     EXPECT_EQ("name  name  address password", StrUtil::trim_pairs(str1, R"(""'')").as_string());
     StringPiece str2("[name {} name  address password]");
     EXPECT_EQ("name {} name  address password", StrUtil::trim_pairs(str2).as_string());
+}
+
+TEST(StrUtil, trim_non_ascii_bytes)
+{
+    const std::string high_byte_prefix("\xff value", 7);
+    EXPECT_EQ(high_byte_prefix, StrUtil::ltrim(high_byte_prefix).as_string());
+
+    const std::string high_byte_suffix("value \xff", 7);
+    EXPECT_EQ(high_byte_suffix, StrUtil::rtrim(high_byte_suffix).as_string());
+    EXPECT_EQ(high_byte_suffix, StrUtil::trim(high_byte_suffix).as_string());
 }
 
 TEST(StrUtil, split_piece)


### PR DESCRIPTION
## What changed

- Return `StringPiece` values shorter than two bytes unchanged from `trim_pairs`.
- Convert inspected bytes to `unsigned char` before calling `std::isspace`.
- Define empty operands as identity values in `PathUtil::concat_path`.
- Add regression coverage for empty, one-byte, custom-pair, high-bit-byte, and empty-path inputs.

## Why

The previous implementation could read before an empty string, underflow a one-byte slice length, violate the ctype input contract, or invoke `front/back` on an empty string. All four paths are undefined behavior in public helpers.

## Root cause

The implementations assumed non-empty ASCII input, but the public signatures and parsing call sites do not enforce those preconditions.

## Impact

No ABI or signature changes. Existing non-empty ASCII semantics remain unchanged. Empty path operands now have explicit identity behavior, and arbitrary byte strings are safe to trim under the existing byte-oriented model.

## Validation

- Full system-GTest CTest build: 26/26 tests passed.
- `StrUtil_unittest` compiled and passed with AddressSanitizer + UndefinedBehaviorSanitizer: 7/7 tests.
- `PathUtil_unittest` compiled and passed with AddressSanitizer + UndefinedBehaviorSanitizer: 7/7 tests.
- Warning flags: `-Wall -Wextra -Wpedantic`.
- `git diff --check`: clean.

## Review structure

Stacked on spec PR #299 so this PR shows only implementation and regression tests.

Issue: #298
Spec: #299