### PR TITLE
perf(cache): enforce concurrent capacity invariants (#301)

### DIFF
--- a/src/core/FileCache.cc
+++ b/src/core/FileCache.cc
@@ -1,92 +1,116 @@
 #include "FileCache.h"
-#include "PathUtil.h"
-#include "FileUtil.h"
-#include "ErrorCode.h"
 
-#include <fstream>
-#include <sys/stat.h>
 #include <algorithm>
-#include <vector>
+#include <cstdint>
+#include <sys/stat.h>
 
 namespace wfrest
 {
 
-bool FileCache::get_file(const std::string& path, std::string& content, size_t start, size_t end)
+namespace
 {
-    // First check if caching is enabled without locking
-    if (!enabled_)
+
+bool snapshot_is_current(const std::string& path,
+                         const std::shared_ptr<CachedFile>& snapshot)
+{
+    struct stat file_stat;
+    if (stat(path.c_str(), &file_stat) != 0 ||
+        !S_ISREG(file_stat.st_mode) || file_stat.st_size < 0)
+    {
         return false;
-
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (!enabled_)
-        return false;
-
-    auto it = cache_.find(path);
-    if (it != cache_.end()) {
-        // Check if file has been modified
-        std::time_t current_mod_time = get_file_modification_time(path);
-        if (current_mod_time <= 0 || current_mod_time > it->second->last_modified) {
-            // File has been modified or doesn't exist anymore
-            return false;
-        }
-
-        // File is in cache and up to date
-        if (end == (size_t)-1 || end >= it->second->content.size()) {
-            end = it->second->content.size();
-        }
-            
-        start = std::min(start, end);
-        content = it->second->content.substr(start, end - start);
-        return true;
     }
-    
-    return false;
+
+    return static_cast<uintmax_t>(file_stat.st_size) ==
+               static_cast<uintmax_t>(snapshot->size) &&
+           file_stat.st_mtime == snapshot->last_modified;
 }
 
-void FileCache::add_file(const std::string& path, const std::string& content, std::time_t last_modified)
+} // namespace
+
+bool FileCache::get_file(const std::string& path, std::string& content,
+                         size_t start, size_t end)
 {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (!enabled_)
+    if (!enabled_.load(std::memory_order_acquire))
+        return false;
+
+    std::shared_ptr<CachedFile> snapshot;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!enabled_.load(std::memory_order_relaxed))
+            return false;
+
+        auto it = cache_.find(path);
+        if (it == cache_.end())
+            return false;
+        snapshot = it->second;
+    }
+
+    if (!snapshot_is_current(path, snapshot))
+    {
+        evict_if_same(path, snapshot);
+        return false;
+    }
+
+    if (end == static_cast<size_t>(-1) || end >= snapshot->content.size())
+        end = snapshot->content.size();
+
+    start = std::min(start, end);
+    content.assign(snapshot->content, start, end - start);
+    return true;
+}
+
+void FileCache::add_file(const std::string& path, const std::string& content,
+                         std::time_t last_modified)
+{
+    if (!enabled_.load(std::memory_order_acquire))
         return;
-        
-    // Check if we need to make room in the cache
-    if (current_size_ + content.size() > max_cache_size_) {
-        manage_cache_size();
-    }
-    
-    // If file already in cache, update it
+
+    auto snapshot = std::make_shared<CachedFile>();
+    snapshot->content = content;
+    snapshot->last_modified = last_modified;
+    snapshot->size = content.size();
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!enabled_.load(std::memory_order_relaxed))
+        return;
+
     auto it = cache_.find(path);
-    if (it != cache_.end()) {
-        current_size_ -= it->second->content.size();
-        it->second->content = content;
-        it->second->last_modified = last_modified;
-        it->second->size = content.size();
-        current_size_ += content.size();
-    } else {
-        // Add new file to cache
-        auto cached_file = std::make_shared<CachedFile>();
-        cached_file->content = content;
-        cached_file->last_modified = last_modified;
-        cached_file->size = content.size();
-        
-        cache_[path] = cached_file;
-        current_size_ += content.size();
+    if (it != cache_.end())
+    {
+        current_size_ -= it->second->size;
+        cache_.erase(it);
     }
+
+    if (snapshot->size > max_cache_size_)
+        return;
+
+    manage_cache_size(snapshot->size);
+    cache_[path] = std::move(snapshot);
+    current_size_ += content.size();
 }
 
 bool FileCache::is_valid(const std::string& path)
 {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (!enabled_)
+    if (!enabled_.load(std::memory_order_acquire))
         return false;
-        
-    auto it = cache_.find(path);
-    if (it == cache_.end()) {
-        return false;
+
+    std::shared_ptr<CachedFile> snapshot;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!enabled_.load(std::memory_order_relaxed))
+            return false;
+
+        auto it = cache_.find(path);
+        if (it == cache_.end())
+            return false;
+        snapshot = it->second;
     }
-    
-    std::time_t current_mod_time = get_file_modification_time(path);
-    return (current_mod_time > 0 && current_mod_time <= it->second->last_modified);
+
+    if (snapshot_is_current(path, snapshot))
+        return true;
+
+    evict_if_same(path, snapshot);
+    return false;
 }
 
 void FileCache::clear()
@@ -96,38 +120,41 @@ void FileCache::clear()
     current_size_ = 0;
 }
 
-std::time_t FileCache::get_file_modification_time(const std::string& path)
+void FileCache::set_max_size(size_t max_size)
 {
-    struct stat file_stat;
-    if (stat(path.c_str(), &file_stat) != 0) {
-        return 0; // Error getting file stats
-    }
-    return file_stat.st_mtime;
+    std::lock_guard<std::mutex> lock(mutex_);
+    max_cache_size_ = max_size;
+    manage_cache_size(0);
 }
 
-void FileCache::manage_cache_size()
+void FileCache::evict_if_same(const std::string& path,
+                              const std::shared_ptr<CachedFile>& snapshot)
 {
-    // Simple approach: remove random items until we have enough space
-    // A more sophisticated approach would use LRU or similar policy
-    
-    // We want to reduce to 75% of max size to avoid frequent cleanup
-    size_t target_size = max_cache_size_ * 3 / 4;
-    
-    // While we're over the target, remove items
-    std::vector<std::string> paths_to_remove;
-    
-    for (auto& entry : cache_) {
-        paths_to_remove.push_back(entry.first);
-        current_size_ -= entry.second->size;
-        
-        if (current_size_ <= target_size) {
-            break;
-        }
-    }
-    
-    for (const auto& path : paths_to_remove) {
-        cache_.erase(path);
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = cache_.find(path);
+    if (it != cache_.end() && it->second == snapshot)
+    {
+        current_size_ -= it->second->size;
+        cache_.erase(it);
     }
 }
 
-} // namespace wfrest 
+void FileCache::manage_cache_size(size_t incoming_size)
+{
+    if (incoming_size > max_cache_size_)
+        return;
+
+    const size_t available_before_insert = max_cache_size_ - incoming_size;
+    const size_t retention_target = max_cache_size_ - max_cache_size_ / 4;
+    const size_t target_size = std::min(available_before_insert,
+                                        retention_target);
+
+    auto it = cache_.begin();
+    while (current_size_ > target_size && it != cache_.end())
+    {
+        current_size_ -= it->second->size;
+        it = cache_.erase(it);
+    }
+}
+
+} // namespace wfrest

--- a/src/core/FileCache.h
+++ b/src/core/FileCache.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <atomic>
 #include <mutex>
 #include <memory>
 #include <ctime>
@@ -36,7 +37,7 @@ public:
     void clear();
     
     // Set maximum cache size
-    void set_max_size(size_t max_size) { max_cache_size_ = max_size; }
+    void set_max_size(size_t max_size);
     
     // Get current cache size
     size_t size() const { 
@@ -47,17 +48,16 @@ public:
     // Enable/Disable caching
     void enable() { 
         std::lock_guard<std::mutex> lock(mutex_);
-        enabled_ = true; 
+        enabled_.store(true, std::memory_order_release);
     }
     
     void disable() { 
         std::lock_guard<std::mutex> lock(mutex_);
-        enabled_ = false; 
+        enabled_.store(false, std::memory_order_release);
     }
     
-    bool is_enabled() const { 
-        std::lock_guard<std::mutex> lock(mutex_);
-        return enabled_; 
+    bool is_enabled() const {
+        return enabled_.load(std::memory_order_acquire);
     }
 
 private:
@@ -68,20 +68,20 @@ private:
     FileCache(const FileCache&) = delete;
     FileCache& operator=(const FileCache&) = delete;
     
-    // Check file modification time
-    std::time_t get_file_modification_time(const std::string& path);
-    
-    // Remove least recently used items when cache is full
-    void manage_cache_size();
+    void evict_if_same(const std::string& path,
+                       const std::shared_ptr<CachedFile>& snapshot);
+
+    // Remove entries until an incoming object can fit within the size bound.
+    void manage_cache_size(size_t incoming_size);
 
 private:
     std::unordered_map<std::string, std::shared_ptr<CachedFile>> cache_;
     mutable std::mutex mutex_; // mutex for thread safety
     size_t max_cache_size_;
     size_t current_size_;
-    bool enabled_;
+    std::atomic<bool> enabled_;
 };
 
 } // namespace wfrest
 
-#endif // WFREST_FILECACHE_H_ 
+#endif // WFREST_FILECACHE_H_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,7 @@ set(UNIT_TEST_LIST
 	RouteTable_unittest
 	HttpDef_unittest
 	FileUtil_unittest
+	FileCache_unittest
 	PathUtil_unittest
 )
 

--- a/test/FileCache_unittest.cc
+++ b/test/FileCache_unittest.cc
@@ -1,0 +1,241 @@
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <sys/stat.h>
+#include <unistd.h>
+#include <utime.h>
+
+#include "wfrest/FileCache.h"
+
+using namespace wfrest;
+
+class FileCacheTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        cache_.enable();
+        cache_.clear();
+        cache_.set_max_size(kDefaultMaxSize);
+    }
+
+    void TearDown() override
+    {
+        cache_.enable();
+        cache_.clear();
+        cache_.set_max_size(kDefaultMaxSize);
+        for (const auto& path : paths_)
+            std::remove(path.c_str());
+    }
+
+    std::string create_file(const std::string& content)
+    {
+        std::string path = "/tmp/wfrest-file-cache-" +
+                           std::to_string(static_cast<long long>(getpid())) + "-" +
+                           std::to_string(paths_.size());
+        paths_.push_back(path);
+
+        std::ofstream output(path.c_str(), std::ios::binary | std::ios::trunc);
+        EXPECT_TRUE(output.is_open());
+        output.write(content.data(), content.size());
+        EXPECT_TRUE(output.good());
+        return path;
+    }
+
+    void overwrite_file(const std::string& path, const std::string& content)
+    {
+        std::ofstream output(path.c_str(), std::ios::binary | std::ios::trunc);
+        ASSERT_TRUE(output.is_open());
+        output.write(content.data(), content.size());
+        ASSERT_TRUE(output.good());
+    }
+
+    std::time_t modification_time(const std::string& path)
+    {
+        struct stat file_stat;
+        EXPECT_EQ(stat(path.c_str(), &file_stat), 0);
+        return file_stat.st_mtime;
+    }
+
+    static const size_t kDefaultMaxSize = 100 * 1024 * 1024;
+    FileCache& cache_ = FileCache::instance();
+    std::vector<std::string> paths_;
+};
+
+const size_t FileCacheTest::kDefaultMaxSize;
+
+TEST_F(FileCacheTest, range_reads_are_half_open_and_clamped)
+{
+    const std::string content = "abcdef";
+    const std::string path = create_file(content);
+    cache_.add_file(path, content, modification_time(path));
+
+    std::string output;
+    EXPECT_TRUE(cache_.get_file(path, output));
+    EXPECT_EQ(output, "abcdef");
+
+    EXPECT_TRUE(cache_.get_file(path, output, 1, 4));
+    EXPECT_EQ(output, "bcd");
+
+    EXPECT_TRUE(cache_.get_file(path, output, 4, 99));
+    EXPECT_EQ(output, "ef");
+
+    EXPECT_TRUE(cache_.get_file(path, output, 99, 4));
+    EXPECT_TRUE(output.empty());
+}
+
+TEST_F(FileCacheTest, replacement_has_exact_byte_accounting)
+{
+    cache_.add_file("replacement", std::string(8, 'a'), 1);
+    EXPECT_EQ(cache_.size(), 8U);
+
+    cache_.add_file("replacement", std::string(3, 'b'), 2);
+    EXPECT_EQ(cache_.size(), 3U);
+}
+
+TEST_F(FileCacheTest, insertion_reserves_capacity_and_rejects_oversized_entries)
+{
+    cache_.set_max_size(100);
+    for (size_t i = 0; i < 70; ++i)
+        cache_.add_file("small-" + std::to_string(i), "x", 1);
+    ASSERT_EQ(cache_.size(), 70U);
+
+    cache_.add_file("incoming", std::string(40, 'i'), 1);
+    EXPECT_LE(cache_.size(), 100U);
+
+    cache_.clear();
+    cache_.set_max_size(10);
+    cache_.add_file("first", std::string(6, 'a'), 1);
+    EXPECT_EQ(cache_.size(), 6U);
+
+    cache_.add_file("second", std::string(6, 'b'), 1);
+    EXPECT_LE(cache_.size(), 10U);
+
+    const size_t size_before_oversized_insert = cache_.size();
+    cache_.add_file("oversized", std::string(11, 'c'), 1);
+    EXPECT_EQ(cache_.size(), size_before_oversized_insert);
+
+    cache_.clear();
+    cache_.add_file("replacement", std::string(6, 'd'), 1);
+    cache_.add_file("replacement", std::string(11, 'e'), 2);
+    EXPECT_EQ(cache_.size(), 0U);
+}
+
+TEST_F(FileCacheTest, shrinking_the_limit_evicts_immediately)
+{
+    cache_.add_file("first", std::string(20, 'a'), 1);
+    cache_.add_file("second", std::string(20, 'b'), 1);
+    EXPECT_EQ(cache_.size(), 40U);
+
+    cache_.set_max_size(20);
+    EXPECT_LE(cache_.size(), 20U);
+
+    cache_.set_max_size(0);
+    EXPECT_EQ(cache_.size(), 0U);
+}
+
+TEST_F(FileCacheTest, stale_same_timestamp_entry_is_evicted)
+{
+    const std::string path = create_file("old");
+    const std::time_t original_mtime = modification_time(path);
+    cache_.add_file(path, "old", original_mtime);
+    ASSERT_EQ(cache_.size(), 3U);
+
+    overwrite_file(path, "changed");
+    struct utimbuf original_times = {original_mtime, original_mtime};
+    ASSERT_EQ(utime(path.c_str(), &original_times), 0);
+    ASSERT_EQ(modification_time(path), original_mtime);
+
+    std::string output;
+    EXPECT_FALSE(cache_.get_file(path, output));
+    EXPECT_EQ(cache_.size(), 0U);
+}
+
+TEST_F(FileCacheTest, deleted_entry_is_evicted_during_validation)
+{
+    const std::string path = create_file("content");
+    cache_.add_file(path, "content", modification_time(path));
+    ASSERT_EQ(cache_.size(), 7U);
+    ASSERT_EQ(std::remove(path.c_str()), 0);
+
+    EXPECT_FALSE(cache_.is_valid(path));
+    EXPECT_EQ(cache_.size(), 0U);
+}
+
+TEST_F(FileCacheTest, disabled_cache_rejects_new_work)
+{
+    const std::string path = create_file("content");
+    cache_.disable();
+    cache_.add_file(path, "content", modification_time(path));
+    EXPECT_EQ(cache_.size(), 0U);
+
+    std::string output;
+    EXPECT_FALSE(cache_.get_file(path, output));
+
+    cache_.enable();
+    cache_.add_file(path, "content", modification_time(path));
+    EXPECT_TRUE(cache_.get_file(path, output));
+    EXPECT_EQ(output, "content");
+}
+
+TEST_F(FileCacheTest, concurrent_configuration_and_access_preserve_the_bound)
+{
+    const std::string content = "concurrent-content";
+    const std::string path = create_file(content);
+    const std::time_t mtime = modification_time(path);
+    std::atomic<bool> start(false);
+
+    auto wait_for_start = [&start]() {
+        while (!start.load(std::memory_order_acquire))
+            std::this_thread::yield();
+    };
+
+    std::thread writer([&]() {
+        wait_for_start();
+        for (size_t i = 0; i < 2000; ++i)
+            cache_.add_file(path, content, mtime);
+    });
+
+    std::thread reader([&]() {
+        wait_for_start();
+        std::string output;
+        for (size_t i = 0; i < 2000; ++i)
+        {
+            cache_.get_file(path, output);
+            cache_.is_valid(path);
+            cache_.size();
+        }
+    });
+
+    std::thread configurer([&]() {
+        wait_for_start();
+        for (size_t i = 0; i < 1000; ++i)
+        {
+            cache_.set_max_size(i % 64);
+            if (i % 2 == 0)
+                cache_.disable();
+            else
+                cache_.enable();
+        }
+    });
+
+    start.store(true, std::memory_order_release);
+    writer.join();
+    reader.join();
+    configurer.join();
+
+    cache_.enable();
+    cache_.set_max_size(32);
+    cache_.add_file(path, content, mtime);
+    EXPECT_LE(cache_.size(), 32U);
+
+    std::string output;
+    EXPECT_TRUE(cache_.get_file(path, output));
+    EXPECT_EQ(output, content);
+}


### PR DESCRIPTION
## What changed

- Replaced the racy `enabled_` fast-path flag with an atomic while retaining mutex-ordered configuration.
- Publish immutable shared cache snapshots; hits now release the global cache mutex before `stat` and content copying.
- Synchronized `set_max_size` and immediately evict after shrinking.
- Reserve capacity for incoming objects, avoid size arithmetic overflow, and reject entries larger than the configured maximum.
- Replace same-key entries with exact byte accounting.
- Validate exact mtime plus file size and evict stale/deleted snapshots only when they have not been concurrently replaced.
- Added `FileCache_unittest` with eight deterministic invariant, edge, and concurrency tests.

## Why

The old cache could exceed its documented memory limit, retain a single oversized object, race on enable/configuration state, serialize hits around filesystem and string work, and permanently retain stale entries.

## Root cause

Capacity cleanup considered only current occupancy, published cache objects were mutated in place under one coarse lock, and configuration fields did not share a single synchronization model.

## Impact

Public method signatures and range semantics are unchanged. Cache hits have shorter critical sections. The configured content-byte limit is now strict after insertion and resize. In-flight readers may finish from an acquired immutable snapshot after a later disable/clear, while new snapshot acquisition observes the new state.

## Validation

- Full CTest suite: 27/27 passed, including the newly registered cache suite.
- Focused ASan+UBSan build: 8/8 cache tests passed.
- Concurrency stress: 2,000 adds, 4,000 get/validation operations, and 1,000 resize/enable transitions passed while preserving the final bound.
- Production source compiled with C++11 plus `-Wall -Wextra -Wpedantic`.
- ThreadSanitizer binary built, but this host cannot initialize TSAN (`unexpected memory mapping`) in either PIE or non-PIE mode; this is reported as an environment limitation, not a passing TSAN run.
- `git diff --check`: clean.

## Review structure

Stacked on spec PR #302 so this PR shows only implementation and tests.

Issue: #301
Spec: #302