### PR TITLE
fix(file): make ranged responses consistent (#304)

### DIFF
--- a/docs/cn/send_file.md
+++ b/docs/cn/send_file.md
@@ -60,4 +60,15 @@ int main()
     }
     return 0;
 }
-``` 
+```
+
+## 范围语义
+
+`File(path, start, end)` 和 `CachedFile(path, start, end)` 使用左闭右开区间：
+包含 `start`，不包含 `end`。将 `end` 设为 `-1` 表示读取到文件末尾；负数
+`start` 表示从文件尾部倒数，例如 `File(path, -5, -1)` 返回最后 5 个字节。
+
+完整文件响应使用 `200`，不包含 `Content-Range`。部分文件响应使用 `206`，
+并按照 RFC 9110 生成末字节位置为闭区间的 `Content-Range`。超过文件末尾的
+`end` 会被截断；无效范围或空的部分范围返回 `416`，同时包含
+`Content-Range: bytes */<file-size>`。

--- a/docs/send_file.md
+++ b/docs/send_file.md
@@ -61,3 +61,15 @@ int main()
     return 0;
 }
 ```
+
+## Range semantics
+
+`File(path, start, end)` and `CachedFile(path, start, end)` use a half-open
+range: `start` is included and `end` is excluded. Passing `-1` as `end` reads
+through EOF. A negative `start` selects a suffix, so `File(path, -5, -1)`
+returns the final five bytes.
+
+Full-file responses use status `200` without a `Content-Range` header. Partial
+responses use status `206` and an RFC 9110 `Content-Range` header whose final
+byte position is inclusive. Ends beyond EOF are clamped. Invalid or empty
+partial ranges return status `416` with `Content-Range: bytes */<file-size>`.

--- a/src/core/HttpFile.cc
+++ b/src/core/HttpFile.cc
@@ -1,12 +1,16 @@
 #include "workflow/WFTaskFactory.h"
 
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
 #include <sys/stat.h>
+#include <type_traits>
 
 #include "HttpFile.h"
 #include "HttpMsg.h"
 #include "PathUtil.h"
 #include "HttpServerTask.h"
-#include "FileUtil.h"
 #include "ErrorCode.h"
 #include "FileCache.h"
 
@@ -23,12 +27,136 @@ struct SaveFileContext
     HttpFile::FileIOArgsFunc fileio_args_func;
 };
 
-// Add a structure to hold both the response and path for cache callback
+struct FileRange
+{
+    size_t start;
+    size_t end;
+    bool partial;
+};
+
+struct FileMetadata
+{
+    size_t size;
+    std::time_t last_modified;
+};
+
+struct ReadContext
+{
+    HttpResp *resp;
+    size_t expected_size;
+};
+
 struct CacheContext
 {
     HttpResp *resp;
     std::string path;
+    size_t file_size;
+    size_t start;
+    size_t end;
+    std::time_t last_modified;
 };
+
+bool normalize_file_range(size_t file_size, size_t encoded_start,
+                          size_t encoded_end, FileRange *range)
+{
+    using SignedSize = std::make_signed<size_t>::type;
+    const size_t max_absolute =
+        static_cast<size_t>(std::numeric_limits<SignedSize>::max());
+
+    size_t start;
+    if (encoded_start > max_absolute)
+    {
+        const size_t suffix_size = ~encoded_start + 1;
+        if (suffix_size == 0 || suffix_size > file_size)
+            return false;
+        start = file_size - suffix_size;
+    }
+    else
+    {
+        start = encoded_start;
+    }
+
+    size_t end;
+    if (encoded_end == static_cast<size_t>(-1))
+    {
+        end = file_size;
+    }
+    else
+    {
+        if (encoded_end > max_absolute)
+            return false;
+        end = std::min(encoded_end, file_size);
+    }
+
+    if (file_size == 0)
+    {
+        const bool valid_empty_end =
+            encoded_end == 0 || encoded_end == static_cast<size_t>(-1);
+        if (start != 0 || end != 0 || !valid_empty_end)
+            return false;
+    }
+    else if (start >= file_size || end <= start)
+    {
+        return false;
+    }
+
+    range->start = start;
+    range->end = end;
+    range->partial = start != 0 || end != file_size;
+    return true;
+}
+
+int prepare_file_response(const std::string& path, size_t encoded_start,
+                          size_t encoded_end, HttpResp *resp,
+                          FileMetadata *metadata, FileRange *range)
+{
+    struct stat file_stat;
+    if (stat(path.c_str(), &file_stat) != 0 || !S_ISREG(file_stat.st_mode))
+        return StatusNotFound;
+
+    if (file_stat.st_size < 0 ||
+        static_cast<uintmax_t>(file_stat.st_size) >
+            static_cast<uintmax_t>(std::numeric_limits<size_t>::max()))
+    {
+        return StatusFileReadError;
+    }
+
+    metadata->size = static_cast<size_t>(file_stat.st_size);
+    metadata->last_modified = file_stat.st_mtime;
+
+    if (!normalize_file_range(metadata->size, encoded_start, encoded_end, range))
+    {
+        resp->headers["Content-Range"] =
+            "bytes */" + std::to_string(metadata->size);
+        return StatusFileRangeInvalid;
+    }
+
+    http_content_type content_type = CONTENT_TYPE_NONE;
+    const std::string suffix = PathUtil::suffix(path);
+    if (!suffix.empty())
+        content_type = ContentType::to_enum_by_suffix(suffix);
+    if (content_type == CONTENT_TYPE_NONE || content_type == CONTENT_TYPE_UNDEFINED)
+        content_type = APPLICATION_OCTET_STREAM;
+    resp->headers["Content-Type"] = ContentType::to_str(content_type);
+
+    resp->headers.erase("Content-Range");
+    if (range->partial)
+    {
+        resp->set_status(206);
+        resp->headers["Content-Range"] =
+            "bytes " + std::to_string(range->start) + "-" +
+            std::to_string(range->end - 1) + "/" +
+            std::to_string(metadata->size);
+    }
+
+    return StatusOK;
+}
+
+void clear_file_response_metadata(HttpResp *resp)
+{
+    resp->headers.erase("Content-Range");
+    resp->headers.erase("Content-Type");
+}
 
 /*
 We do not occupy any thread to read the file, but generate an asynchronous file reading task
@@ -43,14 +171,18 @@ void pread_callback(WFFileIOTask *pread_task)
 {
     FileIOArgs *args = pread_task->get_args();
     long ret = pread_task->get_retval();
-    auto *resp = static_cast<HttpResp *>(pread_task->user_data);
+    auto *read_ctx = static_cast<ReadContext *>(pread_task->user_data);
+    HttpResp *resp = read_ctx->resp;
 
-    if (pread_task->get_state() != WFT_STATE_SUCCESS || ret < 0)
+    if (pread_task->get_state() != WFT_STATE_SUCCESS || ret < 0 ||
+        static_cast<uintmax_t>(ret) !=
+            static_cast<uintmax_t>(read_ctx->expected_size))
     {
+        clear_file_response_metadata(resp);
         resp->Error(StatusFileReadError);
     } else
     {
-        resp->append_output_body_nocopy(args->buf, ret);
+        resp->append_output_body_nocopy(args->buf, static_cast<size_t>(ret));
     }
 }
 
@@ -83,35 +215,21 @@ void pread_cache_callback(WFFileIOTask *pread_task)
     long ret = pread_task->get_retval();
     auto *cache_ctx = static_cast<CacheContext *>(pread_task->user_data);
     HttpResp *resp = cache_ctx->resp;
-    HttpServerTask *server_task = task_of(resp);
-    
-    // Check if the task was successful
-    if (pread_task->get_state() != WFT_STATE_SUCCESS || ret < 0)
+
+    if (pread_task->get_state() != WFT_STATE_SUCCESS || ret < 0 ||
+        static_cast<uintmax_t>(ret) !=
+            static_cast<uintmax_t>(cache_ctx->file_size))
     {
+        clear_file_response_metadata(resp);
         resp->Error(StatusFileReadError);
-        delete cache_ctx; // Clean up
         return;
     }
-    
-    // Get path from the context
-    const std::string &path = cache_ctx->path;
-    size_t size = ret;
-    
-    // Create a string to store the file content
-    std::string *content = new std::string(static_cast<char*>(args->buf), size);
-    
-    // Add to cache before sending response
-    struct stat file_stat;
-    if (stat(path.c_str(), &file_stat) == 0) {
-        FileCache::instance().add_file(path, *content, file_stat.st_mtime);
-    }
-    
-    // Add the content to the response body and set up cleanup
-    resp->append_output_body_nocopy(content->c_str(), content->size());
-    server_task->add_callback([content, cache_ctx](HttpTask *) {
-        delete content;
-        delete cache_ctx;
-    });
+
+    std::string content(static_cast<char*>(args->buf), cache_ctx->file_size);
+    FileCache::instance().add_file(cache_ctx->path, content,
+                                   cache_ctx->last_modified);
+    resp->String(content.substr(cache_ctx->start,
+                                cache_ctx->end - cache_ctx->start));
 }
 
 }  // namespace
@@ -120,61 +238,37 @@ void pread_cache_callback(WFFileIOTask *pread_task)
 // note : [start, end)
 int HttpFile::send_file(const std::string &path, size_t file_start, size_t file_end, HttpResp *resp)
 {
-    if(!PathUtil::is_file(path))
-    {
-        return StatusNotFound;
-    }
-    int start = file_start;
-    int end = file_end;
-    if (end == -1 || start < 0)
-    {
-        size_t file_size;
-        int ret = FileUtil::size(path, &file_size);
+    FileMetadata metadata;
+    FileRange range;
+    int ret = prepare_file_response(path, file_start, file_end, resp,
+                                    &metadata, &range);
+    if (ret != StatusOK)
+        return ret;
 
-        if (ret != StatusOK)
-        {
-            return ret;
-        }
-        if (end == -1) end = file_size;
-        if (start < 0) start = file_size + start;
-    }
+    const size_t size = range.end - range.start;
+    if (size == 0)
+        return StatusOK;
 
-    if (end <= start)
-    {
-        return StatusFileRangeInvalid;
-    }
-
-    http_content_type content_type = CONTENT_TYPE_NONE;
-    std::string suffix = PathUtil::suffix(path);
-    if(!suffix.empty())
-    {
-        content_type = ContentType::to_enum_by_suffix(suffix);
-    }
-    if (content_type == CONTENT_TYPE_NONE || content_type == CONTENT_TYPE_UNDEFINED) {
-        content_type = APPLICATION_OCTET_STREAM;
-    }
-    resp->headers["Content-Type"] = ContentType::to_str(content_type);
-
-    size_t size = end - start;
     void *buf = malloc(size);
+    if (!buf)
+    {
+        clear_file_response_metadata(resp);
+        return StatusFileReadError;
+    }
 
     HttpServerTask *server_task = task_of(resp);
-    server_task->add_callback([buf](HttpTask *server_task)
-                              {
-                                  free(buf);
-                              });
-    // https://datatracker.ietf.org/doc/html/rfc7233#section-4.2
-    // Content-Range: bytes 42-1233/1234
-    resp->headers["Content-Range"] = "bytes " + std::to_string(start)
-                                            + "-" + std::to_string(end)
-                                            + "/" + std::to_string(size);
+    auto *read_ctx = new ReadContext{resp, size};
+    server_task->add_callback([buf, read_ctx](HttpTask *) {
+        free(buf);
+        delete read_ctx;
+    });
 
     WFFileIOTask *pread_task = WFTaskFactory::create_pread_task(path,
                                                                 buf,
                                                                 size,
-                                                                static_cast<off_t>(start),
+                                                                static_cast<off_t>(range.start),
                                                                 pread_callback);
-    pread_task->user_data = resp;
+    pread_task->user_data = read_ctx;
     **server_task << pread_task;
     return StatusOK;
 }
@@ -268,79 +362,50 @@ void HttpFile::save_file(const std::string &dst_path, std::string &&content,
 int HttpFile::send_cached_file(const std::string &path, size_t file_start, size_t file_end, HttpResp *resp)
 {
     FileCache& cache = FileCache::instance();
-    
-    if(!PathUtil::is_file(path))
-    {
-        return StatusNotFound;
-    }
-    
-    // Check file size and other metadata
-    size_t file_size;
-    int ret = FileUtil::size(path, &file_size);
+    if (!cache.is_enabled())
+        return send_file(path, file_start, file_end, resp);
+
+    FileMetadata metadata;
+    FileRange range;
+    int ret = prepare_file_response(path, file_start, file_end, resp,
+                                    &metadata, &range);
     if (ret != StatusOK)
-    {
         return ret;
-    }
-    
-    int start = file_start;
-    int end = file_end;
-    
-    if (end == -1)
-        end = file_size;
-    if (start < 0)
-        start = file_size + start;
 
-    if (end <= start)
+    if (metadata.size == 0)
     {
-        return StatusFileRangeInvalid;
-    }
-
-    http_content_type content_type = CONTENT_TYPE_NONE;
-    std::string suffix = PathUtil::suffix(path);
-    if(!suffix.empty())
-    {
-        content_type = ContentType::to_enum_by_suffix(suffix);
-    }
-    if (content_type == CONTENT_TYPE_NONE || content_type == CONTENT_TYPE_UNDEFINED) {
-        content_type = APPLICATION_OCTET_STREAM;
-    }
-    resp->headers["Content-Type"] = ContentType::to_str(content_type);
-
-    // Set Content-Range header
-    resp->headers["Content-Range"] = "bytes " + std::to_string(start)
-                                            + "-" + std::to_string(end)
-                                            + "/" + std::to_string(file_size);
-    
-    // Try to get the file from cache
-    std::string file_content;
-    if (cache.get_file(path, file_content, start, end))
-    {
-        // File is in cache
-        resp->String(std::move(file_content));
+        cache.add_file(path, "", metadata.last_modified);
+        resp->String(std::string());
         return StatusOK;
     }
     
-    // File not in cache - use async approach just like send_file
+    std::string file_content;
+    if (cache.get_file(path, file_content, range.start, range.end))
+    {
+        resp->String(std::move(file_content));
+        return StatusOK;
+    }
+
     HttpServerTask *server_task = task_of(resp);
-    void *buf = malloc(file_size); // Allocate for whole file
-    if (!buf) {
+    void *buf = malloc(metadata.size);
+    if (!buf)
+    {
+        clear_file_response_metadata(resp);
         return StatusFileReadError;
     }
-    
-    server_task->add_callback([buf](HttpTask *) {
+
+    auto *cache_ctx = new CacheContext{resp, path, metadata.size,
+                                       range.start, range.end,
+                                       metadata.last_modified};
+    server_task->add_callback([buf, cache_ctx](HttpTask *) {
         free(buf);
+        delete cache_ctx;
     });
-    
-    // Create a context to hold both the response and path
-    auto *cache_ctx = new CacheContext;
-    cache_ctx->resp = resp;
-    cache_ctx->path = path;
-    
-    // Create async read task
+
     WFFileIOTask *pread_task = WFTaskFactory::create_pread_task(path,
                                                                 buf,
-                                                                file_size, // Read the whole file
-                                                                0, // Always start from beginning
+                                                                metadata.size,
+                                                                0,
                                                                 pread_cache_callback);
     pread_task->user_data = cache_ctx;
     **server_task << pread_task;

--- a/src/core/HttpMsg.cc
+++ b/src/core/HttpMsg.cc
@@ -691,6 +691,9 @@ void HttpResp::Error(int error_code, const std::string &errmsg)
     case StatusRouteNotFound:
         status_code = 404;
         break;
+    case StatusFileRangeInvalid:
+        status_code = 416;
+        break;
     default:
         break;
     }
@@ -1159,4 +1162,3 @@ HttpResp &HttpResp::operator=(HttpResp&& other)
 }
 
 } // namespace wfrest
-

--- a/test/HttpServer/file_test.cc
+++ b/test/HttpServer/file_test.cc
@@ -1,8 +1,14 @@
 #include "workflow/WFFacilities.h"
 #include <gtest/gtest.h>
+#include <algorithm>
+#include <fcntl.h>
 #include <fstream>
+#include <limits>
+#include <type_traits>
+#include <unistd.h>
 #include "wfrest/HttpServer.h"
 #include "wfrest/ErrorCode.h"
+#include "wfrest/FileCache.h"
 #include "wfrest/FileUtil.h"
 #include "wfrest/PathUtil.h"
 #include "wfrest/Json.h"
@@ -16,8 +22,12 @@ class FileTest
 public:
     static void create_file(const std::string &path)
     {
-        std::string file_body = generate_file_content();
-        bool write_ok = FileTestUtil::write_file(path, file_body);
+        create_file(path, generate_file_content());
+    }
+
+    static void create_file(const std::string &path, const std::string &content)
+    {
+        bool write_ok = FileTestUtil::write_file(path, content);
         EXPECT_TRUE(write_ok);
         EXPECT_TRUE(FileUtil::file_exists(path));
     }
@@ -67,34 +77,91 @@ public:
         {
             client_task->set_callback([&wait_group, start, end](WFHttpTask *task)
             {
-                const void *body;
-                size_t body_len;
-                HttpResponse *resp = task->get_resp();
-                resp->get_parsed_body(&body, &body_len);
-                HttpHeaderMap header(resp);
-                std::string content_type = header.get("Content-Type");
-                EXPECT_EQ(content_type, "text/plain");
-                std::string content_range = header.get("Content-Range");
-                std::string file_body = generate_file_content();
-
-                int exp_start = start;
-                int exp_end = end;
-                if(exp_end == -1) exp_end = file_body.size();
-                if(exp_start < 0) exp_start = file_body.size() + start;
-
-                EXPECT_EQ(content_range, "bytes " + std::to_string(exp_start)
-                                        + "-" + std::to_string(exp_end)
-                                        + "/" + std::to_string(exp_end - exp_start));
-
-                std::string file_body_range = file_body.substr(exp_start, exp_end - exp_start);
-                EXPECT_EQ(file_body_range, std::string(static_cast<const char *>(body), body_len));
-
+                verify_response(task, generate_file_content(), start, end);
                 wait_group.done();
             });
         }
         client_task->start();
         wait_group.wait();
         svr.stop();
+    }
+
+    static void process_cached_twice(const std::string &path,
+                                     size_t start,
+                                     size_t end)
+    {
+        FileCache& cache = FileCache::instance();
+        cache.enable();
+        cache.clear();
+        cache.set_max_size(100 * 1024 * 1024);
+
+        HttpServer svr;
+        svr.GET("/file", [&path, start, end](const HttpReq *, HttpResp *resp)
+        {
+            resp->CachedFile(path, start, end);
+        });
+        ASSERT_EQ(svr.start("127.0.0.1", 8888), 0);
+
+        for (int request_number = 0; request_number < 2; ++request_number)
+        {
+            WFFacilities::WaitGroup wait_group(1);
+            WFHttpTask *client_task = create_http_task("file");
+            client_task->set_callback([&wait_group, start, end](WFHttpTask *task)
+            {
+                verify_response(task, generate_file_content(), start, end);
+                wait_group.done();
+            });
+            client_task->start();
+            wait_group.wait();
+            EXPECT_EQ(cache.size(), generate_file_content().size());
+        }
+
+        svr.stop();
+        cache.clear();
+    }
+
+    static void verify_response(WFHttpTask *task,
+                                const std::string &file_body,
+                                size_t start,
+                                size_t end)
+    {
+        const void *body = nullptr;
+        size_t body_len = 0;
+        HttpResponse *resp = task->get_resp();
+        resp->get_parsed_body(&body, &body_len);
+        HttpHeaderMap header(resp);
+        EXPECT_EQ(header.get("Content-Type"), "text/plain");
+
+        using SignedSize = std::make_signed<size_t>::type;
+        const size_t max_absolute =
+            static_cast<size_t>(std::numeric_limits<SignedSize>::max());
+        size_t expected_start = start;
+        if (start > max_absolute)
+            expected_start = file_body.size() - (~start + 1);
+        size_t expected_end = end == static_cast<size_t>(-1)
+                                  ? file_body.size()
+                                  : std::min(end, file_body.size());
+
+        const bool partial = expected_start != 0 ||
+                             expected_end != file_body.size();
+        EXPECT_STREQ(resp->get_status_code(), partial ? "206" : "200");
+        if (partial)
+        {
+            EXPECT_EQ(header.get("Content-Range"),
+                      "bytes " + std::to_string(expected_start) + "-" +
+                      std::to_string(expected_end - 1) + "/" +
+                      std::to_string(file_body.size()));
+        }
+        else
+        {
+            EXPECT_TRUE(header.get("Content-Range").empty());
+        }
+
+        std::string actual_body;
+        if (body_len > 0)
+            actual_body.assign(static_cast<const char *>(body), body_len);
+        EXPECT_EQ(actual_body,
+                  file_body.substr(expected_start, expected_end - expected_start));
     }
     static WFHttpTask *create_http_task(const std::string &path)
     {
@@ -155,6 +222,126 @@ TEST(HttpServer, file_range5)
     FileTest::delete_file(path);
 }
 
+TEST(HttpServer, file_range_end_is_clamped_to_eof)
+{
+    std::string path = "./test.txt";
+    FileTest::create_file(path);
+    FileTest::process(path, 95, 200);
+    FileTest::delete_file(path);
+}
+
+TEST(HttpServer, full_file_has_no_content_range)
+{
+    std::string path = "./test.txt";
+    FileTest::create_file(path);
+    FileTest::process(path, 0, -1);
+    FileTest::delete_file(path);
+}
+
+TEST(HttpServer, empty_file_is_served_as_full_content)
+{
+    std::string path = "./empty.txt";
+    FileTest::create_file(path, "");
+    FileTest::process(path, 0, -1, [](WFHttpTask *task) {
+        const void *body = nullptr;
+        size_t body_len = 0;
+        HttpResponse *resp = task->get_resp();
+        resp->get_parsed_body(&body, &body_len);
+        HttpHeaderMap header(resp);
+        EXPECT_STREQ(resp->get_status_code(), "200");
+        EXPECT_TRUE(header.get("Content-Range").empty());
+        EXPECT_EQ(body_len, 0U);
+    });
+    FileTest::delete_file(path);
+}
+
+TEST(HttpServer, empty_file_partial_range_is_invalid)
+{
+    std::string path = "./empty.txt";
+    FileTest::create_file(path, "");
+    FileTest::process(path, 0, 1, [](WFHttpTask *task) {
+        HttpResponse *resp = task->get_resp();
+        HttpHeaderMap header(resp);
+        EXPECT_STREQ(resp->get_status_code(), "416");
+        EXPECT_EQ(header.get("Content-Range"), "bytes */0");
+    });
+    FileTest::delete_file(path);
+}
+
+TEST(HttpServer, cached_range_miss_and_hit_are_identical)
+{
+    std::string path = "./test.txt";
+    FileTest::create_file(path);
+    FileTest::process_cached_twice(path, 10, 20);
+    FileTest::delete_file(path);
+}
+
+TEST(HttpServer, disabled_cache_delegates_to_ranged_file_path)
+{
+    std::string path = "./test.txt";
+    FileTest::create_file(path);
+    FileCache& cache = FileCache::instance();
+    cache.clear();
+    cache.disable();
+
+    HttpServer svr;
+    WFFacilities::WaitGroup wait_group(1);
+    svr.GET("/file", [&path](const HttpReq *, HttpResp *resp)
+    {
+        resp->CachedFile(path, 10, 20);
+    });
+    ASSERT_EQ(svr.start("127.0.0.1", 8888), 0);
+
+    WFHttpTask *client_task = FileTest::create_http_task("file");
+    client_task->set_callback([&wait_group](WFHttpTask *task)
+    {
+        FileTest::verify_response(task, FileTest::generate_file_content(), 10, 20);
+        wait_group.done();
+    });
+    client_task->start();
+    wait_group.wait();
+    EXPECT_EQ(cache.size(), 0U);
+
+    svr.stop();
+    cache.enable();
+    FileTest::delete_file(path);
+}
+
+TEST(HttpServer, file_range_above_int_max)
+{
+    if (sizeof(size_t) < 8 ||
+        std::numeric_limits<off_t>::max() <= std::numeric_limits<int>::max())
+    {
+        return;
+    }
+
+    const std::string path = "./large-sparse.txt";
+    const size_t file_size =
+        static_cast<size_t>(std::numeric_limits<int>::max()) + 4096;
+    const size_t start = file_size - 4;
+    int fd = open(path.c_str(), O_CREAT | O_TRUNC | O_RDWR, 0600);
+    ASSERT_GE(fd, 0);
+    ASSERT_EQ(ftruncate(fd, static_cast<off_t>(file_size)), 0);
+    ASSERT_EQ(pwrite(fd, "tail", 4, static_cast<off_t>(start)), 4);
+    ASSERT_EQ(close(fd), 0);
+
+    FileTest::process(path, start, -1, [file_size, start](WFHttpTask *task) {
+        const void *body = nullptr;
+        size_t body_len = 0;
+        HttpResponse *resp = task->get_resp();
+        resp->get_parsed_body(&body, &body_len);
+        HttpHeaderMap header(resp);
+        EXPECT_STREQ(resp->get_status_code(), "206");
+        EXPECT_EQ(header.get("Content-Range"),
+                  "bytes " + std::to_string(start) + "-" +
+                  std::to_string(file_size - 1) + "/" +
+                  std::to_string(file_size));
+        ASSERT_EQ(body_len, 4U);
+        EXPECT_EQ(std::string(static_cast<const char *>(body), body_len), "tail");
+    });
+    FileTest::delete_file(path);
+}
+
 TEST(HttpServer, file_no_extension)
 {
     std::string path = "./test_file";
@@ -193,9 +380,50 @@ TEST(HttpServer, file_range_invalid)
         HttpHeaderMap header(resp);
         std::string content_type = header.get("Content-Type");
         EXPECT_EQ(content_type, "application/json");
+        EXPECT_STREQ(resp->get_status_code(), "416");
+        EXPECT_EQ(header.get("Content-Range"), "bytes */100");
         std::string body_str(static_cast<const char *>(body), body_len);
         Json js = Json::parse(body_str);
         EXPECT_EQ(js["errmsg"].get<std::string>(), "File Range Invalid");
+    });
+    FileTest::delete_file(path);
+}
+
+TEST(HttpServer, file_suffix_before_start_is_invalid)
+{
+    std::string path = "./test.txt";
+    FileTest::create_file(path);
+    FileTest::process(path, -101, -1, [](WFHttpTask *task) {
+        HttpResponse *resp = task->get_resp();
+        HttpHeaderMap header(resp);
+        EXPECT_STREQ(resp->get_status_code(), "416");
+        EXPECT_EQ(header.get("Content-Range"), "bytes */100");
+    });
+    FileTest::delete_file(path);
+}
+
+TEST(HttpServer, file_start_at_eof_is_invalid)
+{
+    std::string path = "./test.txt";
+    FileTest::create_file(path);
+    FileTest::process(path, 100, -1, [](WFHttpTask *task) {
+        HttpResponse *resp = task->get_resp();
+        HttpHeaderMap header(resp);
+        EXPECT_STREQ(resp->get_status_code(), "416");
+        EXPECT_EQ(header.get("Content-Range"), "bytes */100");
+    });
+    FileTest::delete_file(path);
+}
+
+TEST(HttpServer, negative_file_end_other_than_eof_is_invalid)
+{
+    std::string path = "./test.txt";
+    FileTest::create_file(path);
+    FileTest::process(path, 0, -2, [](WFHttpTask *task) {
+        HttpResponse *resp = task->get_resp();
+        HttpHeaderMap header(resp);
+        EXPECT_STREQ(resp->get_status_code(), "416");
+        EXPECT_EQ(header.get("Content-Range"), "bytes */100");
     });
     FileTest::delete_file(path);
 }


### PR DESCRIPTION
## What changed

- Added one `size_t`-safe half-open range normalizer shared by `File` and `CachedFile`.
- Decode documented negative suffix starts with defined unsigned arithmetic; reject unsupported negative ends.
- Clamp explicit ends to EOF and retain offsets above `INT_MAX`.
- Emit 200 without Content-Range for full content, 206 with inclusive last position and total size for partial content, and 416 with `bytes */size` for invalid ranges.
- Verify regular-file size in one stat path and check allocation/short reads.
- Carry normalized start/end through cache-miss callbacks, cache the full snapshot, and send only the requested slice.
- Delegate `CachedFile` to the ordinary path while caching is disabled.
- Handle full empty files without a zero-byte allocation.
- Document range semantics in English and Chinese.
- Expanded file-server coverage from 10 to 20 cases.

## Why

The old implementation generated RFC-invalid headers, used Content-Range with status 200, narrowed offsets to `int`, and returned an entire file on the first cached range request but a slice on subsequent hits.

## Root cause

Cached and uncached range logic evolved independently, while the half-open application API was copied directly into an HTTP field whose positions are inclusive.

## Impact

Public signatures remain unchanged. Corrected wire behavior is intentionally observable: partial responses are now 206 with `bytes start-(end-1)/total`; invalid ranges are 416; full responses no longer carry meaningless Content-Range. Existing negative-start examples continue to work.

## Validation

- Focused server file suite: 20/20 cases passed.
- Focused suite repeated 20 times with `--gtest_break_on_failure`: 400/400 case executions passed.
- Complete CTest suite: 27/27 passed.
- Sparse file test served the final four bytes from an offset above `INT_MAX` without whole-file allocation.
- Cached miss and hit produced identical 206 status, Content-Range, and 10-byte body.
- C++11 production build passed. Additional `-Wall -Wextra -Wpedantic` diagnostics were confined to unchanged Workflow dependency headers.
- `git diff --check`: clean.

## Standards reference

RFC 9110 Sections 14.4 and 15.3.7: https://www.rfc-editor.org/rfc/rfc9110.html#name-content-range

## Review structure

Stacked on spec PR #305 so this PR shows implementation, docs, and tests only.

Issue: #304
Spec: #305