### PR TITLE
fix(cookie): parse and serialize safe cookie fields (#316)

### DIFF
--- a/docs/cn/cookie.md
+++ b/docs/cn/cookie.md
@@ -10,13 +10,13 @@ int main()
 {
     HttpServer svr;
 
-    // curl --cookie "name=chanchan, passwd=123" "http://ip:port/cookie"
+    // curl --cookie "name=chanchan; passwd=123" "http://ip:port/cookie"
     svr.GET("/cookie", [](const HttpReq *req, HttpResp *resp)
     {
         const std::map<std::string, std::string> &cookie = req->cookies();
         if(cookie.empty())  // 没有cookie
         {
-            HttpCookie cookie;
+            HttpCookie cookie("name", "chanchan");
             // 您可以设置的内容：
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
             cookie.set_path("/").set_http_only(true);
@@ -42,6 +42,13 @@ int main()
     return 0;
 }
 ```
+
+请求 Cookie 使用分号分隔。wfrest 会保留第一个 `=` 之后的全部内容，接受空值，
+并在所有 `Cookie` 请求头中保留第一个重复字段名；格式错误的名称或值会被跳过。
+
+响应 Cookie 的名称和值必须已经符合 Cookie 语法；包含控制字符或危险分隔符时，
+对应的 `Set-Cookie` 不会发送。删除 Cookie 时可使用空值和明确的非正有效期，例如
+`HttpCookie("session", "").set_max_age(0).set_path("/")`。
 
 以下是一个更具体的示例，您可以查看[教程](https://github.com/wfrest/wfrest/discussions/60)
 
@@ -139,4 +146,4 @@ svr.GET("/multi", [](const HttpReq *req, HttpResp *resp)
     resp->set_status(HttpStatusOK);
     resp->String("登录成功");
 });
-``` 
+```

--- a/docs/cookie.md
+++ b/docs/cookie.md
@@ -10,13 +10,13 @@ int main()
 {
     HttpServer svr;
 
-    // curl --cookie "name=chanchan, passwd=123" "http://ip:port/cookie"
+    // curl --cookie "name=chanchan; passwd=123" "http://ip:port/cookie"
     svr.GET("/cookie", [](const HttpReq *req, HttpResp *resp)
     {
         const std::map<std::string, std::string> &cookie = req->cookies();
         if(cookie.empty())  // no cookie
         {
-            HttpCookie cookie;
+            HttpCookie cookie("name", "chanchan");
             // What you can set :
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
             cookie.set_path("/").set_http_only(true);
@@ -42,6 +42,15 @@ int main()
     return 0;
 }
 ```
+
+Request cookie pairs are separated by semicolons. wfrest preserves `=` bytes
+after the first separator, accepts empty values, and keeps the first duplicate
+name across all `Cookie` header fields. Malformed names or values are skipped.
+
+Response cookie names and values must already follow cookie syntax; unsafe
+control or delimiter bytes cause that `Set-Cookie` field to be skipped. To
+delete a cookie, use an empty value with an explicit non-positive age, for
+example `HttpCookie("session", "").set_max_age(0).set_path("/")`.
 
 Here is a more specific example, you can see the the [tutorial](https://github.com/wfrest/wfrest/discussions/60)
 

--- a/src/core/HttpCookie.cc
+++ b/src/core/HttpCookie.cc
@@ -1,104 +1,177 @@
-#include <vector>
 #include "HttpCookie.h"
-#include "StrUtil.h"
 
 using namespace wfrest;
 
-std::map<std::string, std::string> HttpCookie::split(const StringPiece &cookie_piece)
+namespace
 {
-    std::map<std::string, std::string> res;
 
-    if (cookie_piece.empty())
-        return res;
-
-    // user=wfrest, passwd=123
-    // [user=wfest] [ passwd=123]
-    std::vector<StringPiece> arr = StrUtil::split_piece<StringPiece>(cookie_piece, ',');
-
-    if (arr.empty())
-        return res;
-
-    std::map<StringPiece, StringPiece> piece_res;
-
-    for (const auto &ele: arr)
+bool is_token_char(unsigned char ch)
+{
+    if ((ch >= '0' && ch <= '9') ||
+        (ch >= 'A' && ch <= 'Z') ||
+        (ch >= 'a' && ch <= 'z'))
     {
-        if (ele.empty())
-            continue;
+        return true;
+    }
 
-        // [user, wfrest]
-        std::vector<StringPiece> kv = StrUtil::split_piece<StringPiece>(ele, '=');
-        size_t kv_size = kv.size();
-        StringPiece &key = kv[0];
+    switch (ch)
+    {
+        case '!': case '#': case '$': case '%': case '&': case '\'':
+        case '*': case '+': case '-': case '.': case '^': case '_':
+        case '`': case '|': case '~':
+            return true;
+        default:
+            return false;
+    }
+}
 
-        if (key.empty() || piece_res.count(key) > 0)
-            continue;
+bool is_cookie_octet(unsigned char ch)
+{
+    return ch == 0x21 ||
+           (ch >= 0x23 && ch <= 0x2B) ||
+           (ch >= 0x2D && ch <= 0x3A) ||
+           (ch >= 0x3C && ch <= 0x5B) ||
+           (ch >= 0x5D && ch <= 0x7E);
+}
 
-        if (kv_size == 1)
+bool is_valid_name(const std::string &name)
+{
+    if (name.empty())
+        return false;
+
+    for (unsigned char ch : name)
+    {
+        if (!is_token_char(ch))
+            return false;
+    }
+    return true;
+}
+
+bool is_valid_value(const std::string &value)
+{
+    for (unsigned char ch : value)
+    {
+        if (!is_cookie_octet(ch))
+            return false;
+    }
+    return true;
+}
+
+bool is_valid_attribute(const std::string &value)
+{
+    for (unsigned char ch : value)
+    {
+        if (ch < 0x20 || ch > 0x7E || ch == ';')
+            return false;
+    }
+    return true;
+}
+
+void trim_ows(const char **begin, const char **end)
+{
+    while (*begin < *end && (**begin == ' ' || **begin == '\t'))
+        ++*begin;
+    while (*end > *begin && ((*end)[-1] == ' ' || (*end)[-1] == '\t'))
+        --*end;
+}
+
+bool parse_value(const char *begin, const char *end, std::string *value)
+{
+    if (begin < end && (*begin == '"' || end[-1] == '"'))
+    {
+        if (end - begin < 2 || *begin != '"' || end[-1] != '"')
+            return false;
+        ++begin;
+        --end;
+    }
+
+    value->assign(begin, static_cast<size_t>(end - begin));
+    return is_valid_value(*value);
+}
+
+} // namespace
+
+std::map<std::string, std::string> HttpCookie::split(
+    const StringPiece &cookie_piece)
+{
+    std::map<std::string, std::string> result;
+    if (cookie_piece.empty())
+        return result;
+
+    const char *segment = cookie_piece.begin();
+
+    while (segment < cookie_piece.end())
+    {
+        const char *segment_end = segment;
+        while (segment_end < cookie_piece.end() && *segment_end != ';')
+            ++segment_end;
+
+        const char *separator = segment;
+        while (separator < segment_end && *separator != '=')
+            ++separator;
+
+        if (separator < segment_end)
         {
-            piece_res.emplace(StrUtil::trim(key), "");
-            continue;
+            const char *name_begin = segment;
+            const char *name_end = separator;
+            const char *value_begin = separator + 1;
+            const char *value_end = segment_end;
+            trim_ows(&name_begin, &name_end);
+            trim_ows(&value_begin, &value_end);
+
+            std::string name(name_begin, static_cast<size_t>(name_end - name_begin));
+            std::string value;
+            if (is_valid_name(name) && parse_value(value_begin, value_end, &value))
+                result.emplace(std::move(name), std::move(value));
         }
 
-        StringPiece &val = kv[1];
-
-        if (val.empty())
-            piece_res.emplace(StrUtil::trim(key), "");
-        else
-            piece_res.emplace(StrUtil::trim(key), StrUtil::trim(val));
-    }
-    for (auto &piece: piece_res)
-    {
-        res.emplace(piece.first.as_string(), piece.second.as_string());
+        segment = segment_end < cookie_piece.end()
+                      ? segment_end + 1
+                      : cookie_piece.end();
     }
 
-    return res;
+    return result;
+}
+
+HttpCookie::operator bool() const
+{
+    return is_valid_name(key_) && is_valid_value(value_) &&
+           is_valid_attribute(domain_) && is_valid_attribute(path_);
 }
 
 std::string HttpCookie::dump() const
 {
+    if (!static_cast<bool>(*this))
+        return {};
+
     std::string ret;
     ret.reserve(key_.size() + value_.size() + 30);
     ret.append(key_).append("=").append(value_).append("; ");
-    // If both Expires and Max-Age are set, Max-Age has precedence.
-    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
-    bool has_max_age = max_age_ > 0;
-    if (has_max_age)
+    if (has_max_age_)
     {
-        ret.append("Max-Age").append("=").append(std::to_string(max_age_)).append("; ");
+        ret.append("Max-Age=").append(std::to_string(max_age_)).append("; ");
     }
-    if (!has_max_age && expires_.valid())
+    else if (expires_.valid())
     {
         ret.append("Expires=")
                 .append(expires_.to_format_str("%a, %d %b %Y %H:%M:%S GMT"))
                 .append("; ");
     }
     if (!domain_.empty())
-    {
         ret.append("Domain=").append(domain_).append("; ");
-    }
     if (!path_.empty())
-    {
         ret.append("Path=").append(path_).append("; ");
-    }
     if (secure_)
-    {
         ret.append("Secure; ");
-    }
     if (http_only_)
-    {
         ret.append("HttpOnly; ");
-    }
-    std::string same_site = same_site_to_str(same_site_);
-    if(!same_site.empty())
-    {
+
+    const std::string same_site = same_site_to_str(same_site_);
+    if (!same_site.empty())
         ret.append("SameSite=").append(same_site).append("; ");
-    }
-    // Cookies with SameSite=None must now also specify 
-    // the Secure attribute (they require a secure context/HTTPS).
-    if(same_site == "None" && !secure_)
-    {
+    if (same_site_ == SameSite::NONE && !secure_)
         ret.append("Secure; ");
-    } 
-    ret.resize(ret.length() - 2);  
+
+    ret.resize(ret.size() - 2);
     return ret;
 }

--- a/src/core/HttpCookie.h
+++ b/src/core/HttpCookie.h
@@ -37,8 +37,7 @@ class HttpCookie : public Copyable
 {
 public:
     // Check if the cookie is empty
-    explicit operator bool() const
-    { return (!key_.empty()) && (!value_.empty()); }
+    explicit operator bool() const;
 
     std::string dump() const;
 
@@ -102,6 +101,7 @@ public:
     HttpCookie &set_max_age(int max_age)
     {
         max_age_ = max_age;
+        has_max_age_ = true;
         return *this;
     }
 
@@ -142,6 +142,9 @@ public:
     int max_age() const
     { return max_age_; }
 
+    bool has_max_age() const
+    { return has_max_age_; }
+
     bool is_secure() const
     { return secure_; }
 
@@ -170,6 +173,7 @@ private:
 
     Timestamp expires_;
     int max_age_ = 0;
+    bool has_max_age_ = false;
     bool secure_ = false;
     bool http_only_ = false;
 

--- a/src/core/HttpMsg.cc
+++ b/src/core/HttpMsg.cc
@@ -626,18 +626,25 @@ void HttpReq::fill_header_map()
 
 const std::map<std::string, std::string> &HttpReq::cookies() const
 {
-    if (cookies_.empty() && this->has_header("Cookie"))
+    if (!cookies_parsed_)
     {
-        const std::string &cookie = this->header("Cookie");
-        StringPiece cookie_piece(cookie);
-        cookies_ = HttpCookie::split(cookie_piece);
+        cookies_parsed_ = true;
+        const auto header_it = headers_.find("Cookie");
+        if (header_it != headers_.end())
+        {
+            for (const std::string &header_value : header_it->second)
+            {
+                const auto parsed = HttpCookie::split(StringPiece(header_value));
+                cookies_.insert(parsed.begin(), parsed.end());
+            }
+        }
     }
     return cookies_;
 }
 
 const std::string &HttpReq::cookie(const std::string &key) const
 {
-    if(cookies_.empty())
+    if (!cookies_parsed_)
     {
         this->cookies();
     }
@@ -656,6 +663,7 @@ HttpReq::HttpReq(HttpReq&& other)
     route_params_(std::move(other.route_params_)),
     query_params_(std::move(other.query_params_)),
     cookies_(std::move(other.cookies_)),
+    cookies_parsed_(other.cookies_parsed_),
     multi_part_(std::move(other.multi_part_)),
     headers_(std::move(other.headers_)),
     parsed_uri_(std::move(other.parsed_uri_))
@@ -677,6 +685,7 @@ HttpReq &HttpReq::operator=(HttpReq&& other)
     route_params_ = std::move(other.route_params_);
     query_params_ = std::move(other.query_params_);
     cookies_ = std::move(other.cookies_);
+    cookies_parsed_ = other.cookies_parsed_;
     multi_part_ = std::move(other.multi_part_);
     headers_ = std::move(other.headers_);
     parsed_uri_ = std::move(other.parsed_uri_);

--- a/src/core/HttpMsg.h
+++ b/src/core/HttpMsg.h
@@ -130,6 +130,7 @@ private:
     std::map<std::string, std::string> route_params_;
     std::map<std::string, std::string> query_params_;
     mutable std::map<std::string, std::string> cookies_;
+    mutable bool cookies_parsed_ = false;
 
     MultiPartForm multi_part_;
     HeaderMap headers_;

--- a/src/core/HttpServerTask.cc
+++ b/src/core/HttpServerTask.cc
@@ -83,6 +83,9 @@ CommMessageOut *HttpServerTask::message_out()
     for(auto &cookie : resp->cookies())
     {
         std::string cookie_str = cookie.dump();
+        if (cookie_str.empty())
+            continue;
+
         header.name = "Set-Cookie";
         header.name_len = 10;
         header.value = cookie_str.c_str();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -99,6 +99,7 @@ set(SERVER_UNIT_TEST_LIST
 	send_form_test
 	multipart_test
 	push_test
+	cookie_test
 	blueprint_test
 	cn_url_test
 )

--- a/test/HttpCookie_unittest.cc
+++ b/test/HttpCookie_unittest.cc
@@ -1,4 +1,4 @@
-#include <unordered_map>
+#include <vector>
 #include <gtest/gtest.h>
 #include "wfrest/HttpCookie.h"
 
@@ -28,7 +28,19 @@ TEST(HttpCookie, same_site)
 
 TEST(HttpCookie, split)
 {
-    StringPiece cookie("user=chanchan,passwd=123");
+    const auto res = HttpCookie::split(StringPiece(
+        "user=chanchan; passwd=123; token=a=b=c; flag=; quoted=\"abc\""));
+    ASSERT_EQ(res.size(), 5U);
+    EXPECT_EQ(res.at("user"), "chanchan");
+    EXPECT_EQ(res.at("passwd"), "123");
+    EXPECT_EQ(res.at("token"), "a=b=c");
+    EXPECT_EQ(res.at("flag"), "");
+    EXPECT_EQ(res.at("quoted"), "abc");
+}
+
+TEST(HttpCookie, split_trim)
+{
+    StringPiece cookie("  user  =  chanchan ;  passwd = 123    ");
     std::map<std::string, std::string> res = HttpCookie::split(cookie);
     auto it = res.begin();
     EXPECT_EQ("passwd", it->first);
@@ -38,14 +50,48 @@ TEST(HttpCookie, split)
     EXPECT_EQ("chanchan", it->second);
 }
 
-TEST(HttpCookie, split_trim)
+TEST(HttpCookie, split_skips_malformed_and_keeps_first)
 {
-    StringPiece cookie("  user  =  chanchan ,  passwd = 123    ");
-    std::map<std::string, std::string> res = HttpCookie::split(cookie);
-    auto it = res.begin();
-    EXPECT_EQ("passwd", it->first);
-    EXPECT_EQ("123", it->second);
-    it++;
-    EXPECT_EQ("user", it->first);
-    EXPECT_EQ("chanchan", it->second);
+    const auto res = HttpCookie::split(StringPiece(
+        "missing; =value; bad name=x; bad=has space; broken=\"quote; "
+        "a=first; a=second; comma=one,two; valid=yes"));
+    ASSERT_EQ(res.size(), 2U);
+    EXPECT_EQ(res.at("a"), "first");
+    EXPECT_EQ(res.at("valid"), "yes");
+}
+
+TEST(HttpCookie, empty_value_and_signed_max_age)
+{
+    HttpCookie cookie("session", "");
+    EXPECT_TRUE(cookie);
+    cookie.set_path("/").set_http_only(true).set_max_age(0);
+    EXPECT_TRUE(cookie.has_max_age());
+    EXPECT_EQ(cookie.dump(), "session=; Max-Age=0; Path=/; HttpOnly");
+
+    cookie.set_max_age(-1);
+    EXPECT_EQ(cookie.dump(), "session=; Max-Age=-1; Path=/; HttpOnly");
+}
+
+TEST(HttpCookie, rejects_unsafe_output)
+{
+    const std::vector<std::string> unsafe_values = {
+        "space value", "quote\"", "comma,", "semi;", "slash\\",
+        "line\rbreak", "line\nbreak", std::string(1, '\x7f'),
+        std::string(1, static_cast<char>(0x80))};
+    for (const std::string &value : unsafe_values)
+    {
+        HttpCookie cookie("name", value);
+        EXPECT_FALSE(cookie);
+        EXPECT_TRUE(cookie.dump().empty());
+    }
+
+    EXPECT_TRUE(HttpCookie("bad name", "value").dump().empty());
+
+    HttpCookie domain("name", "value");
+    domain.set_domain("example.com\r\nInjected: yes");
+    EXPECT_TRUE(domain.dump().empty());
+
+    HttpCookie path("name", "value");
+    path.set_path("/; injected=yes");
+    EXPECT_TRUE(path.dump().empty());
 }

--- a/test/HttpServer/cookie_test.cc
+++ b/test/HttpServer/cookie_test.cc
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+#include "wfrest/HttpServer.h"
+#include "wfrest/Json.h"
+#include "workflow/HttpUtil.h"
+#include "workflow/WFFacilities.h"
+#include "../ClientUtil.h"
+
+using namespace wfrest;
+using namespace protocol;
+
+TEST(HttpServer, cookie_headers_and_safe_output)
+{
+    HttpServer server;
+    WFFacilities::WaitGroup wait_group(1);
+
+    server.GET("/cookies", [](const HttpReq *req, HttpResp *resp)
+    {
+        const auto &cookies = req->cookies();
+        EXPECT_EQ(&cookies, &req->cookies());
+
+        Json result;
+        result["size"] = cookies.size();
+        result["user"] = req->cookie("user");
+        result["role"] = req->cookie("role");
+        result["token"] = req->cookie("token");
+        result["duplicate"] = req->cookie("duplicate");
+        result["flag"] = req->cookie("flag");
+
+        HttpCookie deletion("session", "");
+        deletion.set_max_age(0).set_path("/").set_http_only(true);
+        resp->add_cookie(std::move(deletion));
+
+        HttpCookie invalid("unsafe", "line\r\nInjected: yes");
+        resp->add_cookie(std::move(invalid));
+        resp->Json(result);
+    });
+
+    ASSERT_EQ(server.start("127.0.0.1", 8888), 0);
+
+    WFHttpTask *client = ClientUtil::create_http_task("cookies");
+    client->get_req()->add_header_pair(
+        "Cookie", "user=alice; token=a=b=c; duplicate=first");
+    client->get_req()->add_header_pair(
+        "Cookie", "role=admin; duplicate=second; flag=");
+    client->set_callback([&](WFHttpTask *task)
+    {
+        EXPECT_EQ(task->get_state(), WFT_STATE_SUCCESS);
+        const void *body = nullptr;
+        size_t body_size = 0;
+        const bool parsed_body = task->get_resp()->get_parsed_body(
+            &body, &body_size);
+        EXPECT_TRUE(parsed_body);
+        if (!parsed_body)
+        {
+            wait_group.done();
+            return;
+        }
+        Json result = Json::parse(std::string(
+            static_cast<const char *>(body), body_size));
+        EXPECT_TRUE(result.is_valid());
+        if (!result.is_valid())
+        {
+            wait_group.done();
+            return;
+        }
+        EXPECT_EQ(result["size"].get<int>(), 5);
+        EXPECT_EQ(result["user"].get<std::string>(), "alice");
+        EXPECT_EQ(result["role"].get<std::string>(), "admin");
+        EXPECT_EQ(result["token"].get<std::string>(), "a=b=c");
+        EXPECT_EQ(result["duplicate"].get<std::string>(), "first");
+        EXPECT_EQ(result["flag"].get<std::string>(), "");
+
+        HttpHeaderMap headers(task->get_resp());
+        const auto set_cookies = headers.get_strict("Set-Cookie");
+        EXPECT_EQ(set_cookies.size(), 1U);
+        if (set_cookies.size() == 1)
+        {
+            EXPECT_EQ(set_cookies[0],
+                      "session=; Max-Age=0; Path=/; HttpOnly");
+        }
+        wait_group.done();
+    });
+    client->start();
+
+    wait_group.wait();
+    server.stop();
+}


### PR DESCRIPTION
## What

- replace comma/vector request parsing with a semicolon-delimited single pass that uses only the first equals sign
- validate token names and cookie-octet values, support quoted and empty values, skip malformed pairs, and keep first duplicates
- parse every Cookie header once per request and cache even an empty result
- make empty response values valid and track explicit signed Max-Age separately from its value
- reject unsafe Set-Cookie names, values, Domain, and Path data; skip invalid dumps at header emission
- add seven direct tests, a multi-header request/response integration test, and English/Chinese documentation

## Why

The old parser lost standard semicolon pairs and embedded equals. Empty values and Max-Age=0 could not express deletion cookies, while unvalidated response bytes could cross an HTTP header boundary.

## Validation

- direct HttpCookie suite under ASan + UBSan: 7/7 passed
- focused CTest (HttpCookie + server cookie): 2/2 passed
- full CTest suite: 33/33 passed
- HttpCookie, HttpMsg, and HttpServerTask strict C++11 Wall/Wextra/Wpedantic/Werror compile: passed
- end-to-end: two Cookie fields merged first-wins; one valid deletion Set-Cookie emitted; injected cookie omitted
- git diff --check: passed

## Compatibility

Valid cookies and attributes remain supported. Standard semicolon pairs, embedded equals, empty values, multiple headers, and deletion ages become supported. Obsolete comma splitting and unsafe response bytes are intentionally rejected.

Stacked on #317. Closes #316 after merge.