### PR TITLE
fix(http): make message moves ownership-safe (#319)

### DIFF
--- a/src/core/HttpMsg.cc
+++ b/src/core/HttpMsg.cc
@@ -473,10 +473,11 @@ void mysql_callback(WFMySQLTask *mysql_task)
 HttpReq::HttpReq() : req_data_(new ReqData)
 {}
 
-HttpReq::~HttpReq()
-{
-    delete req_data_;
-}
+HttpReq::HttpReq(HttpRequest &&base_req)
+    : HttpRequest(std::move(base_req)), req_data_(new ReqData)
+{}
+
+HttpReq::~HttpReq() = default;
 
 std::string &HttpReq::body() const
 {
@@ -658,6 +659,7 @@ const std::string &HttpReq::cookie(const std::string &key) const
 HttpReq::HttpReq(HttpReq&& other)
     : HttpRequest(std::move(other)),
     content_type_(other.content_type_),
+    req_data_(std::move(other.req_data_)),
     route_match_path_(std::move(other.route_match_path_)),
     route_full_path_(std::move(other.route_full_path_)),
     route_params_(std::move(other.route_params_)),
@@ -667,18 +669,16 @@ HttpReq::HttpReq(HttpReq&& other)
     multi_part_(std::move(other.multi_part_)),
     headers_(std::move(other.headers_)),
     parsed_uri_(std::move(other.parsed_uri_))
-{
-    req_data_ = other.req_data_;
-    other.req_data_ = nullptr;
-}
+{}
 
 HttpReq &HttpReq::operator=(HttpReq&& other)
 {
+    if (this == &other)
+        return *this;
+
     HttpRequest::operator=(std::move(other));
     content_type_ = other.content_type_;
-
-    req_data_ = other.req_data_;
-    other.req_data_ = nullptr;
+    req_data_ = std::move(other.req_data_);
 
     route_match_path_ = std::move(other.route_match_path_);
     route_full_path_ = std::move(other.route_full_path_);
@@ -1386,6 +1386,9 @@ HttpResp::HttpResp(HttpResp&& other)
 
 HttpResp &HttpResp::operator=(HttpResp&& other)
 {
+    if (this == &other)
+        return *this;
+
     HttpResponse::operator=(std::move(other));
     headers = std::move(other.headers);
     user_data = other.user_data;

--- a/src/core/HttpMsg.h
+++ b/src/core/HttpMsg.h
@@ -108,9 +108,7 @@ public:
 public:
     HttpReq();
 
-    HttpReq(HttpRequest &&base_req)
-        : HttpRequest(std::move(base_req))
-    {}
+    HttpReq(HttpRequest &&base_req);
 
     ~HttpReq();
 
@@ -121,8 +119,8 @@ public:
 private:
     using HeaderMap = std::map<std::string, std::vector<std::string>, MapStringCaseLess>;
 
-    http_content_type content_type_;
-    ReqData *req_data_;
+    http_content_type content_type_ = CONTENT_TYPE_NONE;
+    std::unique_ptr<ReqData> req_data_;
 
     std::string route_match_path_;
     std::string route_full_path_;
@@ -324,7 +322,7 @@ public:
 
 public:
     std::map<std::string, std::string, MapStringCaseLess> headers;
-    void *user_data;
+    void *user_data = nullptr;
 
 private:
     std::vector<HttpCookie> cookies_;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,6 +70,7 @@ set(UNIT_TEST_LIST
 	PathUtil_unittest
 	UriUtil_unittest
 	HttpContent_unittest
+	HttpMsg_unittest
 	PushWriteUtil_unittest
 )
 

--- a/test/HttpMsg_unittest.cc
+++ b/test/HttpMsg_unittest.cc
@@ -1,0 +1,183 @@
+#include <cstdint>
+#include <cstring>
+#include <new>
+#include <string>
+#include <gtest/gtest.h>
+#include "wfrest/HttpMsg.h"
+
+using namespace wfrest;
+
+namespace
+{
+
+std::string output_body(const protocol::HttpMessage &message)
+{
+    std::string body;
+    EXPECT_TRUE(message.get_output_body_merged(body));
+    return body;
+}
+
+} // namespace
+
+TEST(HttpReqMove, initializes_default_and_wrapped_requests)
+{
+    HttpReq request;
+    EXPECT_EQ(request.content_type(), CONTENT_TYPE_NONE);
+    EXPECT_TRUE(request.body().empty());
+
+    alignas(HttpReq) unsigned char storage[sizeof(HttpReq)];
+    std::memset(storage, 0xA5, sizeof(storage));
+    protocol::HttpRequest base;
+    ASSERT_TRUE(base.set_method("POST"));
+    ASSERT_TRUE(base.set_request_uri("/wrapped"));
+
+    HttpReq *wrapped = new (storage) HttpReq(std::move(base));
+    EXPECT_EQ(wrapped->content_type(), CONTENT_TYPE_NONE);
+    EXPECT_TRUE(wrapped->body().empty());
+    EXPECT_STREQ(wrapped->get_method(), "POST");
+    EXPECT_STREQ(wrapped->get_request_uri(), "/wrapped");
+    wrapped->~HttpReq();
+}
+
+TEST(HttpReqMove, transfers_all_derived_state)
+{
+    HttpReq source;
+    ASSERT_TRUE(source.set_method("POST"));
+    ASSERT_TRUE(source.set_request_uri("/source"));
+    ASSERT_TRUE(source.add_header_pair(
+        "Content-Type", "application/x-www-form-urlencoded"));
+    ASSERT_TRUE(source.add_header_pair("Cookie", "session=abc"));
+    source.fill_header_map();
+    source.fill_content_type();
+    source.body() = "name=value";
+    EXPECT_EQ(source.form_kv().at("name"), "value");
+    EXPECT_EQ(source.cookies().at("session"), "abc");
+    source.set_route_match_path("tail");
+    source.set_full_path("/route*");
+    source.set_route_params({{"id", "42"}});
+    source.set_query_params({{"page", "3"}});
+
+    HttpReq moved(std::move(source));
+    EXPECT_EQ(moved.content_type(), APPLICATION_URLENCODED);
+    EXPECT_EQ(moved.body(), "name=value");
+    EXPECT_EQ(moved.form_kv().at("name"), "value");
+    EXPECT_EQ(moved.cookie("session"), "abc");
+    EXPECT_EQ(moved.match_path(), "tail");
+    EXPECT_EQ(moved.full_path(), "/route*");
+    EXPECT_EQ(moved.param("id"), "42");
+    EXPECT_EQ(moved.query("page"), "3");
+    EXPECT_EQ(moved.header("Content-Type"),
+              "application/x-www-form-urlencoded");
+
+    source = HttpReq();
+    source.body() = "reused";
+    EXPECT_EQ(source.body(), "reused");
+}
+
+TEST(HttpReqMove, replaces_owned_cache_without_leaks)
+{
+    HttpReq target;
+    target.body() = "initial";
+
+    for (int i = 0; i < 100; ++i)
+    {
+        HttpReq source;
+        source.body() = "body-" + std::to_string(i);
+        target = std::move(source);
+        EXPECT_EQ(target.body(), "body-" + std::to_string(i));
+    }
+}
+
+TEST(HttpReqMove, self_move_preserves_state)
+{
+    HttpReq request;
+    ASSERT_TRUE(request.set_method("PUT"));
+    ASSERT_TRUE(request.set_request_uri("/self"));
+    request.body() = "keep";
+    request.set_route_params({{"id", "7"}});
+    request.set_query_params({{"q", "value"}});
+
+    HttpReq *request_alias = &request;
+    request = std::move(*request_alias);
+
+    EXPECT_STREQ(request.get_method(), "PUT");
+    EXPECT_STREQ(request.get_request_uri(), "/self");
+    EXPECT_EQ(request.body(), "keep");
+    EXPECT_EQ(request.param("id"), "7");
+    EXPECT_EQ(request.query("q"), "value");
+}
+
+TEST(HttpRespMove, initializes_user_data)
+{
+    alignas(HttpResp) unsigned char default_storage[sizeof(HttpResp)];
+    std::memset(default_storage, 0xA5, sizeof(default_storage));
+    HttpResp *response = new (default_storage) HttpResp;
+    EXPECT_EQ(response->user_data, nullptr);
+    response->~HttpResp();
+
+    alignas(HttpResp) unsigned char wrapped_storage[sizeof(HttpResp)];
+    std::memset(wrapped_storage, 0xA5, sizeof(wrapped_storage));
+    protocol::HttpResponse base;
+    ASSERT_TRUE(base.set_status_code("202"));
+    HttpResp *wrapped = new (wrapped_storage) HttpResp(std::move(base));
+    EXPECT_EQ(wrapped->user_data, nullptr);
+    EXPECT_STREQ(wrapped->get_status_code(), "202");
+    wrapped->~HttpResp();
+}
+
+TEST(HttpRespMove, transfers_and_replaces_state)
+{
+    HttpResp target;
+    ASSERT_TRUE(target.set_status_code("400"));
+    ASSERT_TRUE(target.append_output_body("old"));
+    target.headers["X-State"] = "old";
+    target.user_data = reinterpret_cast<void *>(static_cast<uintptr_t>(0x1));
+    target.add_cookie(HttpCookie("old", "cookie"));
+
+    HttpResp source;
+    ASSERT_TRUE(source.set_status_code("201"));
+    ASSERT_TRUE(source.append_output_body("created"));
+    source.headers["X-State"] = "new";
+    source.user_data = reinterpret_cast<void *>(static_cast<uintptr_t>(0x1234));
+    source.add_cookie(HttpCookie("session", "abc"));
+
+    target = std::move(source);
+    EXPECT_STREQ(target.get_status_code(), "201");
+    EXPECT_EQ(output_body(target), "created");
+    EXPECT_EQ(target.headers.at("X-State"), "new");
+    EXPECT_EQ(target.user_data,
+              reinterpret_cast<void *>(static_cast<uintptr_t>(0x1234)));
+    ASSERT_EQ(target.cookies().size(), 1U);
+    EXPECT_EQ(target.cookies()[0].key(), "session");
+    EXPECT_EQ(source.user_data, nullptr);
+
+    HttpResp moved(std::move(target));
+    EXPECT_STREQ(moved.get_status_code(), "201");
+    EXPECT_EQ(output_body(moved), "created");
+    EXPECT_EQ(moved.headers.at("X-State"), "new");
+    EXPECT_EQ(moved.user_data,
+              reinterpret_cast<void *>(static_cast<uintptr_t>(0x1234)));
+    ASSERT_EQ(moved.cookies().size(), 1U);
+    EXPECT_EQ(target.user_data, nullptr);
+}
+
+TEST(HttpRespMove, self_move_preserves_state)
+{
+    HttpResp response;
+    ASSERT_TRUE(response.set_status_code("204"));
+    ASSERT_TRUE(response.append_output_body("keep"));
+    response.headers["X-State"] = "keep";
+    response.user_data = reinterpret_cast<void *>(static_cast<uintptr_t>(0x1234));
+    response.add_cookie(HttpCookie("name", "value"));
+
+    HttpResp *response_alias = &response;
+    response = std::move(*response_alias);
+
+    EXPECT_STREQ(response.get_status_code(), "204");
+    EXPECT_EQ(output_body(response), "keep");
+    EXPECT_EQ(response.headers.at("X-State"), "keep");
+    EXPECT_EQ(response.user_data,
+              reinterpret_cast<void *>(static_cast<uintptr_t>(0x1234)));
+    ASSERT_EQ(response.cookies().size(), 1U);
+    EXPECT_EQ(response.cookies()[0].value(), "value");
+}


### PR DESCRIPTION
## What

- replace the owning raw ReqData pointer with a private unique_ptr
- fully initialize default and HttpRequest-wrapping requests with CONTENT_TYPE_NONE and fresh cache storage
- transfer the cache through unique ownership and guard HttpReq self-move
- default HttpResp user_data to null and guard response self-move
- cover placement-filled constructors, complete derived-state transfers, 100 repeated replacements, source reuse, and request/response self-moves

## Why

The wrapping constructor left ReqData and content_type indeterminate, move assignment leaked the destination cache, request self-move nulled itself, and response user_data was indeterminate and cleared by self-move. Workflow base moves already release and self-guard; wfrest derived state did not.

## Before

An ASan/UBSan probe on test at 9c15ac2 showed:

- wrapping HttpRequest then calling body: high-address SEGV
- move assignment into a populated request: 216-byte LSan leak
- HttpReq self-move then body: null-address SEGV
- placement-filled default response user_data: 0xa5a5a5a5a5a5a5a5, then self-move changed 0x1234 to null

## Validation

- focused HttpMsg lifecycle tests: 7/7 passed
- ASan + UBSan + LeakSanitizer lifecycle tests: 7/7 passed with 100 repeated move assignments and no leaks
- full CTest suite: 34/34 passed, including proxy transfer
- HttpMsg.cc strict C++11 Wall/Wextra/Wpedantic/Werror compile: passed
- placement-filled default and base-wrapping construction: deterministic
- git diff --check: passed

## Compatibility

No public signatures change. ReqData remains private/incomplete and user_data remains non-owning. Existing base-only proxy request moves and full response moves remain compatible.

Stacked on #320. Closes #319 after merge.