### PR TITLE
fix(multipart): parse content disposition safely (#325)

### DIFF
--- a/src/core/HttpContent.cc
+++ b/src/core/HttpContent.cc
@@ -1,6 +1,5 @@
 #include <strings.h>
 #include <utility>
-#include "StrUtil.h"
 #include "HttpContent.h"
 #include "StringPiece.h"
 #include "UriUtil.h"
@@ -56,6 +55,209 @@ bool is_valid_multipart_boundary(const std::string &boundary)
     return true;
 }
 
+bool is_ows(char ch)
+{
+    return ch == ' ' || ch == '\t';
+}
+
+bool is_token_char(unsigned char ch)
+{
+    if ((ch >= '0' && ch <= '9') ||
+        (ch >= 'A' && ch <= 'Z') ||
+        (ch >= 'a' && ch <= 'z'))
+    {
+        return true;
+    }
+
+    switch (ch)
+    {
+        case '!':
+        case '#':
+        case '$':
+        case '%':
+        case '&':
+        case '\'':
+        case '*':
+        case '+':
+        case '-':
+        case '.':
+        case '^':
+        case '_':
+        case '`':
+        case '|':
+        case '~':
+            return true;
+        default:
+            return false;
+    }
+}
+
+unsigned char ascii_lower(unsigned char ch)
+{
+    if (ch >= 'A' && ch <= 'Z')
+        return static_cast<unsigned char>(ch + ('a' - 'A'));
+    return ch;
+}
+
+bool ascii_iequals(const std::string &value, const char *expected)
+{
+    size_t i = 0;
+    while (i < value.size() && expected[i] != '\0')
+    {
+        if (ascii_lower(static_cast<unsigned char>(value[i])) !=
+            ascii_lower(static_cast<unsigned char>(expected[i])))
+        {
+            return false;
+        }
+        ++i;
+    }
+    return i == value.size() && expected[i] == '\0';
+}
+
+void skip_ows(const std::string &value, size_t *cursor)
+{
+    while (*cursor < value.size() && is_ows(value[*cursor]))
+        ++(*cursor);
+}
+
+bool read_token(const std::string &input, size_t *cursor, std::string *value)
+{
+    const size_t begin = *cursor;
+    while (*cursor < input.size() &&
+           is_token_char(static_cast<unsigned char>(input[*cursor])))
+    {
+        ++(*cursor);
+    }
+    if (*cursor == begin)
+        return false;
+
+    value->assign(input.data() + begin, *cursor - begin);
+    return true;
+}
+
+bool is_quoted_text(unsigned char ch)
+{
+    return ch == '\t' || ch == ' ' || ch == '!' ||
+           (ch >= '#' && ch <= '[') ||
+           (ch >= ']' && ch <= '~') || ch >= 0x80;
+}
+
+bool is_quoted_pair_char(unsigned char ch)
+{
+    return ch == '\t' || (ch >= ' ' && ch != 0x7f);
+}
+
+bool read_quoted_value(const std::string &input,
+                       size_t *cursor,
+                       std::string *value)
+{
+    if (*cursor >= input.size() || input[*cursor] != '"')
+        return false;
+
+    ++*cursor;
+    value->clear();
+    while (*cursor < input.size())
+    {
+        const unsigned char ch =
+            static_cast<unsigned char>(input[(*cursor)++]);
+        if (ch == '"')
+            return true;
+
+        if (ch == '\\')
+        {
+            if (*cursor >= input.size())
+                return false;
+            const unsigned char escaped =
+                static_cast<unsigned char>(input[(*cursor)++]);
+            if (!is_quoted_pair_char(escaped))
+                return false;
+            value->push_back(static_cast<char>(escaped));
+        }
+        else
+        {
+            if (!is_quoted_text(ch))
+                return false;
+            value->push_back(static_cast<char>(ch));
+        }
+    }
+    return false;
+}
+
+bool read_parameter_value(const std::string &input,
+                          size_t *cursor,
+                          std::string *value)
+{
+    if (*cursor < input.size() && input[*cursor] == '"')
+        return read_quoted_value(input, cursor, value);
+    return read_token(input, cursor, value);
+}
+
+bool parse_content_disposition(const std::string &input,
+                               std::string *name,
+                               std::string *filename)
+{
+    size_t cursor = 0;
+    skip_ows(input, &cursor);
+
+    std::string disposition;
+    if (!read_token(input, &cursor, &disposition) ||
+        !ascii_iequals(disposition, "form-data"))
+    {
+        return false;
+    }
+
+    bool has_name = false;
+    bool has_filename = false;
+    std::string parsed_name;
+    std::string parsed_filename;
+    skip_ows(input, &cursor);
+    while (cursor < input.size())
+    {
+        if (input[cursor] != ';')
+            return false;
+        ++cursor;
+        skip_ows(input, &cursor);
+
+        std::string key;
+        if (!read_token(input, &cursor, &key))
+            return false;
+        skip_ows(input, &cursor);
+        if (cursor >= input.size() || input[cursor] != '=')
+            return false;
+        ++cursor;
+        skip_ows(input, &cursor);
+
+        std::string value;
+        if (!read_parameter_value(input, &cursor, &value))
+            return false;
+        skip_ows(input, &cursor);
+        if (cursor < input.size() && input[cursor] != ';')
+            return false;
+
+        if (ascii_iequals(key, "name"))
+        {
+            if (has_name)
+                return false;
+            has_name = true;
+            parsed_name = std::move(value);
+        }
+        else if (ascii_iequals(key, "filename"))
+        {
+            if (has_filename)
+                return false;
+            has_filename = true;
+            parsed_filename = std::move(value);
+        }
+    }
+
+    if (!has_name || parsed_name.empty())
+        return false;
+
+    *name = std::move(parsed_name);
+    *filename = std::move(parsed_filename);
+    return true;
+}
+
 } // namespace
 
 std::map<std::string, std::string> Urlencode::parse_post_kv(const StringPiece &body)
@@ -84,40 +286,32 @@ struct multipart_parser_userdata
     std::string part_data;
     std::string name;
     std::string filename;
+    bool disposition_seen;
+    bool disposition_valid;
 
     void handle_header();
 
     void handle_data();
+
+    void reset_part();
 };
 
 void multipart_parser_userdata::handle_header()
 {
-    if (header_field.empty() || header_value.empty()) return;
-    if (strcasecmp(header_field.c_str(), "Content-Disposition") == 0)
+    if (!header_field.empty() &&
+        strcasecmp(header_field.c_str(), "Content-Disposition") == 0)
     {
-        // Content-Disposition: attachment
-        // Content-Disposition: attachment; filename="filename.jpg"
-        // Content-Disposition: form-data; name="avatar"; filename="user.jpg"
-        StringPiece header_val_piece(header_value);
-        std::vector<StringPiece> dispo_list = StrUtil::split_piece<StringPiece>(header_val_piece, ';');
-
-        for (auto &dispo: dispo_list)
+        if (disposition_seen)
         {
-            auto kv = StrUtil::split_piece<StringPiece>(StrUtil::trim(dispo), '=');
-            if (kv.size() == 2)
-            {
-                // name="file"
-                // kv[0] is key(name)
-                // kv[1] is value("file")
-                StringPiece value = StrUtil::trim_pairs(kv[1], R"(""'')");
-                if (kv[0].starts_with(StringPiece("name")))
-                {
-                    name = value.as_string();
-                } else if (kv[0].starts_with(StringPiece("filename")))
-                {
-                    filename = value.as_string();
-                }
-            }
+            disposition_valid = false;
+            name.clear();
+            filename.clear();
+        }
+        else
+        {
+            disposition_seen = true;
+            disposition_valid = parse_content_disposition(
+                header_value, &name, &filename);
         }
     }
     header_field.clear();
@@ -126,16 +320,25 @@ void multipart_parser_userdata::handle_header()
 
 void multipart_parser_userdata::handle_data()
 {
-    if (!name.empty())
+    if (disposition_seen && disposition_valid)
     {
         std::pair<std::string, std::string> formdata;
         formdata.first = filename;
         formdata.second = part_data;
         (*mp)[name] = formdata;
     }
+    reset_part();
+}
+
+void multipart_parser_userdata::reset_part()
+{
+    header_field.clear();
+    header_value.clear();
     name.clear();
     filename.clear();
     part_data.clear();
+    disposition_seen = false;
+    disposition_valid = false;
 }
 
 MultiPartForm::MultiPartForm()
@@ -193,6 +396,7 @@ int MultiPartForm::part_data_cb(multipart_parser *parser, const char *buf, size_
 int MultiPartForm::part_data_begin_cb(multipart_parser *parser)
 {
     auto *userdata = static_cast<multipart_parser_userdata *>(multipart_parser_get_data(parser));
+    userdata->reset_part();
     userdata->state = MP_PART_DATA_BEGIN;
     return 0;
 }
@@ -231,7 +435,7 @@ Form MultiPartForm::parse_multipart(const StringPiece &body) const
     if (parser == nullptr)
         return form;
 
-    multipart_parser_userdata userdata;
+    multipart_parser_userdata userdata{};
     userdata.state = MP_START;
     userdata.mp = &form;
     multipart_parser_set_data(parser, &userdata);

--- a/test/HttpContent_unittest.cc
+++ b/test/HttpContent_unittest.cc
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <vector>
 #include "wfrest/HttpContent.h"
 #include "wfrest/StringPiece.h"
 #include "wfrest/UriUtil.h"
@@ -19,6 +20,15 @@ std::string multipart_body(const std::string &boundary,
     body += value;
     body += "\r\n--" + boundary + closing;
     return body;
+}
+
+std::string multipart_disposition_body(const std::string &boundary,
+                                       const std::string &disposition,
+                                       const std::string &value = "value")
+{
+    return "--" + boundary +
+           "\r\nContent-Disposition: " + disposition +
+           "\r\n\r\n" + value + "\r\n--" + boundary + "--\r\n";
 }
 
 } // namespace
@@ -98,6 +108,100 @@ TEST(MultiPartForm, rejects_invalid_boundaries)
 
     parser.set_boundary(std::string(71, 'a'));
     EXPECT_TRUE(parser.parse_multipart(StringPiece(valid_body)).empty());
+}
+
+TEST(MultiPartForm, parses_structural_content_disposition)
+{
+    MultiPartForm parser;
+    parser.set_boundary("abc");
+
+    Form form = parser.parse_multipart(StringPiece(
+        multipart_disposition_body(
+            "abc",
+            "FORM-DATA ; NAME = upload ; "
+            "FILENAME = \"a=b;c.txt\"; filename*=UTF-8''ignored")));
+    ASSERT_EQ(form.size(), 1U);
+    EXPECT_EQ(form.at("upload").first, "a=b;c.txt");
+    EXPECT_EQ(form.at("upload").second, "value");
+
+    form = parser.parse_multipart(StringPiece(
+        multipart_disposition_body(
+            "abc",
+            "form-data; name=item; filename=\"a\\\"b\\\\c.txt\"; "
+            "filenamex=ignored")));
+    ASSERT_EQ(form.size(), 1U);
+    EXPECT_EQ(form.at("item").first, "a\"b\\c.txt");
+
+    form = parser.parse_multipart(StringPiece(
+        multipart_disposition_body(
+            "abc", "form-data; name=\"up=load;field\"; filename=\"\"")));
+    ASSERT_EQ(form.size(), 1U);
+    EXPECT_TRUE(form.at("up=load;field").first.empty());
+}
+
+TEST(MultiPartForm, rejects_invalid_content_disposition_metadata)
+{
+    MultiPartForm parser;
+    parser.set_boundary("abc");
+
+    std::string nul_disposition = "form-data; name=\"bad";
+    nul_disposition.push_back('\0');
+    nul_disposition += "value\"";
+    const std::vector<std::string> invalid = {
+        "form-data; namex=spoofed",
+        "form-data; filenamex=spoofed",
+        "attachment; name=item",
+        "form-data; filename=file.txt",
+        "form-data; name=\"\"",
+        "form-data; name=one; name=two",
+        "form-data; name=item; filename=one; filename=two",
+        "form-data; name",
+        "form-data; name=",
+        "form-data; name=item;",
+        "form-data; name=\"item\"junk",
+        "form-data; name=\"unterminated",
+        "form-data; name=\"item\"; filename=\"trailing\\",
+        "form-data; na(me=item",
+        nul_disposition,
+        std::string("form-data; name=\"bad") + '\x7f' + "value\""
+    };
+
+    for (const std::string &disposition : invalid)
+    {
+        EXPECT_TRUE(parser.parse_multipart(StringPiece(
+            multipart_disposition_body("abc", disposition))).empty())
+            << disposition;
+    }
+
+    const std::string duplicate_header =
+        "--abc\r\nContent-Disposition: form-data; name=first\r\n"
+        "Content-Disposition: form-data; name=second\r\n"
+        "\r\nvalue\r\n--abc--\r\n";
+    EXPECT_TRUE(parser.parse_multipart(StringPiece(duplicate_header)).empty());
+}
+
+TEST(MultiPartForm, isolates_invalid_disposition_between_parts)
+{
+    MultiPartForm parser;
+    parser.set_boundary("abc");
+
+    const std::string invalid_then_valid =
+        "--abc\r\nContent-Disposition: form-data; namex=bad\r\n"
+        "\r\nbad-data\r\n--abc\r\n"
+        "Content-Disposition: form-data; name=good\r\n"
+        "\r\ngood-data\r\n--abc--\r\n";
+    Form form = parser.parse_multipart(StringPiece(invalid_then_valid));
+    ASSERT_EQ(form.size(), 1U);
+    EXPECT_EQ(form.at("good").second, "good-data");
+
+    const std::string valid_then_invalid =
+        "--abc\r\nContent-Disposition: form-data; name=good\r\n"
+        "\r\ngood-data\r\n--abc\r\n"
+        "Content-Disposition: attachment; name=bad\r\n"
+        "\r\nbad-data\r\n--abc--\r\n";
+    form = parser.parse_multipart(StringPiece(valid_then_invalid));
+    ASSERT_EQ(form.size(), 1U);
+    EXPECT_EQ(form.at("good").second, "good-data");
 }
 
 TEST(MultiPartParser, rejects_invalid_initialization)

--- a/test/HttpServer/multipart_test.cc
+++ b/test/HttpServer/multipart_test.cc
@@ -20,16 +20,26 @@ std::string multipart_body(const std::string &boundary,
            "\r\nvalue\r\n--" + boundary + closing;
 }
 
+std::string multipart_disposition_body(const std::string &boundary,
+                                       const std::string &disposition)
+{
+    return "--" + boundary +
+           "\r\nContent-Disposition: " + disposition +
+           "\r\n\r\nvalue\r\n--" + boundary + "--\r\n";
+}
+
 WFHttpTask *multipart_request(const std::string &content_type,
                               const std::string &body,
                               size_t expected_size,
-                              WFFacilities::WaitGroup *wait_group)
+                              WFFacilities::WaitGroup *wait_group,
+                              const std::string &expected_filename = "")
 {
     WFHttpTask *task = ClientUtil::create_http_task("multipart");
     task->get_req()->set_method("POST");
     task->get_req()->add_header_pair("Content-Type", content_type);
     task->get_req()->append_output_body(body.data(), body.size());
-    task->set_callback([expected_size, wait_group](WFHttpTask *current)
+    task->set_callback([expected_size, expected_filename, wait_group](
+        WFHttpTask *current)
     {
         EXPECT_EQ(current->get_state(), WFT_STATE_SUCCESS);
         const void *body_data = nullptr;
@@ -57,6 +67,8 @@ WFHttpTask *multipart_request(const std::string &content_type,
         if (expected_size == 1)
         {
             EXPECT_EQ(result["value"].get<std::string>(), "value");
+            EXPECT_EQ(result["filename"].get<std::string>(),
+                      expected_filename);
         }
         wait_group->done();
     });
@@ -68,7 +80,7 @@ WFHttpTask *multipart_request(const std::string &content_type,
 TEST(HttpServer, multipart_content_type_and_completion)
 {
     HttpServer server;
-    WFFacilities::WaitGroup wait_group(10);
+    WFFacilities::WaitGroup wait_group(11);
 
     server.POST("/multipart", [](const HttpReq *req, HttpResp *resp)
     {
@@ -77,7 +89,10 @@ TEST(HttpServer, multipart_content_type_and_completion)
         result["kind"] = static_cast<int>(req->content_type());
         result["size"] = form.size();
         if (form.count("field") != 0)
+        {
             result["value"] = form.at("field").second;
+            result["filename"] = form.at("field").first;
+        }
         resp->Json(result);
     });
 
@@ -115,6 +130,12 @@ TEST(HttpServer, multipart_content_type_and_completion)
     tasks.push_back(multipart_request(
         "multipart/form-data; boundary=abc",
         multipart_body("abc", "X\r\n"), 0, &wait_group));
+    tasks.push_back(multipart_request(
+        "multipart/form-data; boundary=disposition",
+        multipart_disposition_body(
+            "disposition",
+            "FORM-DATA; NAME=field; FILENAME=\"a=b;c.txt\""),
+        1, &wait_group, "a=b;c.txt"));
 
     SeriesWork *series = Workflow::create_series_work(tasks.front(), nullptr);
     for (size_t i = 1; i < tasks.size(); ++i)


### PR DESCRIPTION
## Why

`Content-Disposition` was split at every `;` and `=`, recognized keys with `starts_with`, and ignored the disposition type. The current `test` behavior lost `filename="a=b.txt"`, truncated `filename="a;b.txt"`, accepted `namex` as `name`, and accepted `attachment` as form data.

## Plan implemented

1. Replace delimiter splitting with bounds-checked token and quoted-value readers.
2. Require exact ASCII case-insensitive `form-data`, `name`, and `filename`.
3. Preserve quoted `;` and `=`, and decode quoted-pair escapes once.
4. Parse into temporary values and commit only after the complete header validates.
5. Require one non-empty name, allow an optional empty filename, and reject duplicate recognized params or disposition headers.
6. Track and clear explicit per-part disposition state, so an invalid part is skipped without contaminating later valid parts.
7. Add direct syntax/rejection/isolation tests and an HTTP integration case.

## Before and after probe

- equals filename: empty -> `a=b.txt`
- semicolon filename: `"a` -> `a;b.txt`
- `namex`: one spoofed field -> no field
- `attachment`: one field -> no field

## Validation

- strict C++11 `HttpContent.cc` compile with `-Wall -Wextra -Wpedantic -Werror`
- directly instrumented ASan + UBSan + LSan parser suite: 7/7 passed
- focused parser and HTTP multipart CTest: 2/2 passed
- complete CTest suite: 34/34 passed
- original four-case reproduction probe now produces the expected results
- `git diff --check`

Stacked on #326. Implements #325.