### PR TITLE
fix(file): complete and truncate asynchronous saves (#328)

### DIFF
--- a/src/core/HttpFile.cc
+++ b/src/core/HttpFile.cc
@@ -3,9 +3,11 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>
+#include <fcntl.h>
 #include <limits>
 #include <sys/stat.h>
 #include <type_traits>
+#include <unistd.h>
 
 #include "HttpFile.h"
 #include "HttpMsg.h"
@@ -25,6 +27,8 @@ struct SaveFileContext
     std::string content;
     std::string notify_msg;
     HttpFile::FileIOArgsFunc fileio_args_func;
+    int fd = -1;
+    size_t expected_size = 0;
 };
 
 struct FileRange
@@ -188,24 +192,65 @@ void pread_callback(WFFileIOTask *pread_task)
 
 void pwrite_callback(WFFileIOTask *pwrite_task)
 {
-    long ret = pwrite_task->get_retval();
+    const long ret = pwrite_task->get_retval();
     HttpServerTask *server_task = task_of(pwrite_task);
     HttpResp *resp = server_task->get_resp();
     auto *save_context = static_cast<SaveFileContext *>(pwrite_task->user_data);
-    if(save_context->fileio_args_func)
+    FileIOArgs *args = pwrite_task->get_args();
+
+    int close_result = -1;
+    if (save_context->fd >= 0)
     {
-        save_context->fileio_args_func(pwrite_task->get_args());
+        close_result = close(save_context->fd);
+        save_context->fd = -1;
     }
-    if (pwrite_task->get_state() != WFT_STATE_SUCCESS || ret < 0)
+    args->fd = -1;
+
+    if (save_context->fileio_args_func)
+        save_context->fileio_args_func(args);
+
+    const bool complete =
+        pwrite_task->get_state() == WFT_STATE_SUCCESS && ret >= 0 &&
+        static_cast<uintmax_t>(ret) ==
+            static_cast<uintmax_t>(save_context->expected_size) &&
+        close_result == 0;
+    if (!complete)
     {
         resp->Error(StatusFileWriteError);
-    } else
-    {
-        if(!save_context->notify_msg.empty())
-        {
-            resp->append_output_body_nocopy(save_context->notify_msg.c_str(), save_context->notify_msg.size());
-        }
     }
+    else if (!save_context->notify_msg.empty())
+    {
+        resp->append_output_body_nocopy(save_context->notify_msg.c_str(),
+                                        save_context->notify_msg.size());
+    }
+}
+
+void enqueue_save_file(const std::string &dst_path,
+                       HttpResp *resp,
+                       SaveFileContext *save_context)
+{
+    HttpServerTask *server_task = task_of(resp);
+    save_context->expected_size = save_context->content.size();
+    save_context->fd = open(dst_path.c_str(),
+                            O_WRONLY | O_CREAT | O_TRUNC,
+                            0644);
+
+    // An invalid fd keeps open failures on the normal asynchronous callback.
+    WFFileIOTask *pwrite_task = WFTaskFactory::create_pwrite_task(
+        save_context->fd,
+        static_cast<const void *>(save_context->content.c_str()),
+        save_context->expected_size,
+        0,
+        pwrite_callback);
+    pwrite_task->user_data = save_context;
+
+    server_task->add_callback([save_context](HttpTask *)
+    {
+        if (save_context->fd >= 0)
+            close(save_context->fd);
+        delete save_context;
+    });
+    **server_task << pwrite_task;
 }
 
 // Callback for asynchronous file reading in cached mode
@@ -278,50 +323,22 @@ void HttpFile::save_file(const std::string &dst_path, const std::string &content
                         HttpResp *resp, const std::string &notify_msg,
                         const FileIOArgsFunc &func)
 {
-    HttpServerTask *server_task = task_of(resp);
-
     auto *save_context = new SaveFileContext;
     save_context->content = content;    // copy
     save_context->notify_msg = notify_msg;  // copy
-    if (func)
-    {
-        save_context->fileio_args_func = func;
-    }
-    WFFileIOTask *pwrite_task = WFTaskFactory::create_pwrite_task(dst_path,
-                                                                  static_cast<const void *>(save_context->content.c_str()),
-                                                                  save_context->content.size(),
-                                                                  0,
-                                                                  pwrite_callback);
-    **server_task << pwrite_task;
-    server_task->add_callback([save_context](HttpTask *) {
-        delete save_context;
-    });
-    pwrite_task->user_data = save_context;
+    save_context->fileio_args_func = func;
+    enqueue_save_file(dst_path, resp, save_context);
 }
 
 void HttpFile::save_file(const std::string &dst_path, std::string &&content,
                         HttpResp *resp, const std::string &notify_msg,
                         const FileIOArgsFunc &func)
 {
-    HttpServerTask *server_task = task_of(resp);
-
     auto *save_context = new SaveFileContext;
     save_context->content = std::move(content);
-    save_context->notify_msg = std::move(notify_msg);
-    if (func)
-    {
-        save_context->fileio_args_func = func;
-    }
-    WFFileIOTask *pwrite_task = WFTaskFactory::create_pwrite_task(dst_path,
-                                                                  static_cast<const void *>(save_context->content.c_str()),
-                                                                  save_context->content.size(),
-                                                                  0,
-                                                                  pwrite_callback);
-    **server_task << pwrite_task;
-    server_task->add_callback([save_context](HttpTask *) {
-        delete save_context;
-    });
-    pwrite_task->user_data = save_context;
+    save_context->notify_msg = notify_msg;
+    save_context->fileio_args_func = func;
+    enqueue_save_file(dst_path, resp, save_context);
 }
 
 

--- a/test/HttpServer/file_test.cc
+++ b/test/HttpServer/file_test.cc
@@ -1,9 +1,14 @@
 #include "workflow/WFFacilities.h"
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <atomic>
+#include <csignal>
 #include <fcntl.h>
 #include <fstream>
+#include <iterator>
 #include <limits>
+#include <sys/resource.h>
+#include <sys/stat.h>
 #include <type_traits>
 #include <unistd.h>
 #include "wfrest/HttpServer.h"
@@ -50,6 +55,34 @@ public:
         EXPECT_FALSE(PathUtil::is_dir(path));
     }
 
+    static std::string read_file(const std::string &path)
+    {
+        std::ifstream file(path, std::ios::binary);
+        return std::string(std::istreambuf_iterator<char>(file),
+                           std::istreambuf_iterator<char>());
+    }
+
+    static std::string response_body(WFHttpTask *task)
+    {
+        const void *body = nullptr;
+        size_t body_len = 0;
+        if (!task->get_resp()->get_parsed_body(&body, &body_len) ||
+            body_len == 0)
+        {
+            return "";
+        }
+        return std::string(static_cast<const char *>(body), body_len);
+    }
+
+    static void expect_file_write_error(WFHttpTask *task)
+    {
+        EXPECT_EQ(task->get_state(), WFT_STATE_SUCCESS);
+        EXPECT_STREQ(task->get_resp()->get_status_code(), "503");
+        const Json error = Json::parse(response_body(task));
+        ASSERT_TRUE(error.is_valid());
+        EXPECT_EQ(error["errmsg"].get<std::string>(), "File Write Error");
+    }
+
     static void process(const std::string &path,
                         size_t start,
                         size_t end,
@@ -58,7 +91,7 @@ public:
         HttpServer svr;
         WFFacilities::WaitGroup wait_group(1);
 
-        svr.GET("/file", [&path, start, end](const HttpReq *req, HttpResp *resp)
+        svr.GET("/file", [&path, start, end](const HttpReq *, HttpResp *resp)
         {
             resp->File(path, start, end);
         });
@@ -457,10 +490,11 @@ TEST(HttpServer, save_file)
     std::string path = "test.txt";
     EXPECT_FALSE(FileUtil::file_exists(path));
     std::string file_body = FileTest::generate_file_content();
-    svr.GET("/file", [&path, &file_body](const HttpReq *req, HttpResp *resp, SeriesWork *series)
+    svr.GET("/file", [&path, &file_body](const HttpReq *, HttpResp *resp,
+                                         SeriesWork *series)
     {
         resp->Save(path, file_body);
-        series->set_callback([&path, &file_body](const SeriesWork *sereis) {
+        series->set_callback([&path, &file_body](const SeriesWork *) {
             EXPECT_TRUE(FileUtil::file_exists(path));
             std::ifstream file(path);
             std::string str;
@@ -480,7 +514,7 @@ TEST(HttpServer, save_file)
 
     WFHttpTask *client_task = FileTest::create_http_task("file");
 
-    client_task->set_callback([&wait_group](WFHttpTask *task)
+    client_task->set_callback([&wait_group](WFHttpTask *)
     {
         wait_group.done();
     });
@@ -488,4 +522,193 @@ TEST(HttpServer, save_file)
     client_task->start();
     wait_group.wait();
     svr.stop();
+}
+
+TEST(HttpServer, save_file_replaces_existing_contents)
+{
+    const std::string short_path = "./wfrest-save-short.tmp";
+    const std::string empty_path = "./wfrest-save-empty.tmp";
+    const std::string moved_path = "./wfrest-save-moved.tmp";
+    std::remove(moved_path.c_str());
+    FileTest::create_file(short_path, "new-old-tail");
+    FileTest::create_file(empty_path, "must-disappear");
+    std::atomic<int> moved_callback_count{0};
+    std::atomic<int> moved_callback_fd{0};
+    std::atomic<bool> moved_callback_buffer_ok{false};
+
+    HttpServer server;
+    WFFacilities::WaitGroup wait_group(3);
+    server.GET("/short", [&short_path](const HttpReq *, HttpResp *resp)
+    {
+        const std::string content = "new";
+        resp->Save(short_path, content, "saved");
+    });
+    server.GET("/empty", [&empty_path](const HttpReq *, HttpResp *resp)
+    {
+        resp->Save(empty_path, std::string(), "saved");
+    });
+    server.GET("/moved", [&](const HttpReq *, HttpResp *resp)
+    {
+        std::string content = "moved-content";
+        resp->Save(moved_path, std::move(content),
+                   [&](const FileIOArgs *args)
+        {
+            moved_callback_fd.store(args->fd);
+            moved_callback_buffer_ok.store(
+                args->count == 13 &&
+                std::string(static_cast<const char *>(args->buf),
+                            args->count) == "moved-content");
+            moved_callback_count.fetch_add(1);
+        });
+    });
+    ASSERT_EQ(server.start("127.0.0.1", 8888), 0);
+
+    for (const char *route : {"short", "empty"})
+    {
+        WFHttpTask *task = FileTest::create_http_task(route);
+        task->set_callback([&wait_group](WFHttpTask *current)
+        {
+            EXPECT_EQ(current->get_state(), WFT_STATE_SUCCESS);
+            EXPECT_STREQ(current->get_resp()->get_status_code(), "200");
+            EXPECT_EQ(FileTest::response_body(current), "saved");
+            wait_group.done();
+        });
+        task->start();
+    }
+
+    WFHttpTask *moved_task = FileTest::create_http_task("moved");
+    moved_task->set_callback([&wait_group](WFHttpTask *current)
+    {
+        EXPECT_EQ(current->get_state(), WFT_STATE_SUCCESS);
+        EXPECT_STREQ(current->get_resp()->get_status_code(), "200");
+        EXPECT_TRUE(FileTest::response_body(current).empty());
+        wait_group.done();
+    });
+    moved_task->start();
+
+    wait_group.wait();
+    server.stop();
+    EXPECT_EQ(FileTest::read_file(short_path), "new");
+    EXPECT_TRUE(FileTest::read_file(empty_path).empty());
+    EXPECT_EQ(FileTest::read_file(moved_path), "moved-content");
+    EXPECT_EQ(moved_callback_count.load(), 1);
+    EXPECT_EQ(moved_callback_fd.load(), -1);
+    EXPECT_TRUE(moved_callback_buffer_ok.load());
+    FileTest::delete_file(short_path);
+    FileTest::delete_file(empty_path);
+    FileTest::delete_file(moved_path);
+}
+
+TEST(HttpServer, save_file_reports_open_and_device_failures)
+{
+    const std::string missing_parent =
+        "./wfrest-missing-save-parent-" + std::to_string(getpid());
+    const std::string missing_path = missing_parent + "/output.tmp";
+    rmdir(missing_parent.c_str());
+    const bool has_dev_full = access("/dev/full", W_OK) == 0;
+    std::atomic<int> callback_count{0};
+    std::atomic<int> callback_fd{0};
+    std::atomic<size_t> callback_count_arg{0};
+    std::atomic<bool> callback_buffer_ok{false};
+
+    HttpServer server;
+    WFFacilities::WaitGroup wait_group(has_dev_full ? 2 : 1);
+    server.GET("/missing", [&](const HttpReq *, HttpResp *resp)
+    {
+        resp->Save(missing_path, std::string("data"),
+                   [&](const FileIOArgs *args)
+        {
+            callback_fd.store(args->fd);
+            callback_count_arg.store(args->count);
+            callback_buffer_ok.store(
+                std::string(static_cast<const char *>(args->buf),
+                            args->count) == "data");
+            callback_count.fetch_add(1);
+        });
+    });
+    server.GET("/full", [](const HttpReq *, HttpResp *resp)
+    {
+        resp->Save("/dev/full", std::string("data"), "must-not-appear");
+    });
+    ASSERT_EQ(server.start("127.0.0.1", 8888), 0);
+
+    WFHttpTask *missing_task = FileTest::create_http_task("missing");
+    missing_task->set_callback([&wait_group](WFHttpTask *current)
+    {
+        FileTest::expect_file_write_error(current);
+        wait_group.done();
+    });
+    missing_task->start();
+
+    if (has_dev_full)
+    {
+        WFHttpTask *full_task = FileTest::create_http_task("full");
+        full_task->set_callback([&wait_group](WFHttpTask *current)
+        {
+            FileTest::expect_file_write_error(current);
+            EXPECT_EQ(FileTest::response_body(current).find("must-not-appear"),
+                      std::string::npos);
+            wait_group.done();
+        });
+        full_task->start();
+    }
+
+    wait_group.wait();
+    server.stop();
+    EXPECT_EQ(callback_count.load(), 1);
+    EXPECT_EQ(callback_fd.load(), -1);
+    EXPECT_EQ(callback_count_arg.load(), 4U);
+    EXPECT_TRUE(callback_buffer_ok.load());
+    EXPECT_FALSE(FileUtil::file_exists(missing_path));
+}
+
+TEST(HttpServer, save_file_rejects_short_writes)
+{
+    struct rlimit original_limit;
+    if (getrlimit(RLIMIT_FSIZE, &original_limit) != 0 ||
+        original_limit.rlim_max < 5)
+    {
+        GTEST_SKIP() << "RLIMIT_FSIZE cannot be set to five bytes";
+    }
+
+    const std::string path = "./wfrest-save-short-write.tmp";
+    std::remove(path.c_str());
+    HttpServer server;
+    WFFacilities::WaitGroup wait_group(1);
+    server.GET("/short-write", [&path](const HttpReq *, HttpResp *resp)
+    {
+        resp->Save(path, std::string("0123456789"), "must-not-appear");
+    });
+    ASSERT_EQ(server.start("127.0.0.1", 8888), 0);
+
+    const auto original_handler = std::signal(SIGXFSZ, SIG_IGN);
+    struct rlimit limited = original_limit;
+    limited.rlim_cur = 5;
+    if (setrlimit(RLIMIT_FSIZE, &limited) != 0)
+    {
+        std::signal(SIGXFSZ, original_handler);
+        server.stop();
+        GTEST_SKIP() << "RLIMIT_FSIZE update failed";
+    }
+
+    WFHttpTask *task = FileTest::create_http_task("short-write");
+    task->set_callback([&wait_group](WFHttpTask *current)
+    {
+        FileTest::expect_file_write_error(current);
+        EXPECT_EQ(FileTest::response_body(current).find("must-not-appear"),
+                  std::string::npos);
+        wait_group.done();
+    });
+    task->start();
+    wait_group.wait();
+
+    const int restore_limit = setrlimit(RLIMIT_FSIZE, &original_limit);
+    std::signal(SIGXFSZ, original_handler);
+    server.stop();
+    EXPECT_EQ(restore_limit, 0);
+
+    struct stat file_stat;
+    ASSERT_EQ(stat(path.c_str(), &file_stat), 0);
+    EXPECT_EQ(file_stat.st_size, 5);
+    FileTest::delete_file(path);
 }


### PR DESCRIPTION
## Why

`Save()` used a path pwrite opened without `O_TRUNC`, so shorter and empty saves retained old bytes. It also treated any non-negative pwrite result as success: a real 5/10 short write produced a partial file and the success notification.

## Plan implemented

1. Open with `O_WRONLY | O_CREAT | O_TRUNC` and use Workflow fd-based pwrite.
2. Keep fd and expected count in one context shared by const and rvalue overloads.
3. Preserve asynchronous open-failure completion by queuing fd `-1`.
4. Close once in the task callback, set args fd to `-1`, and keep server cleanup as a fallback.
5. Require successful task state, exact byte count, valid fd, and successful close.
6. Invoke `FileIOArgsFunc` on success and failure before deciding the response.
7. Append notification only after complete write and close.

## Behavioral evidence

Before:
- writing `new` over `new-old-tail` left `new-old-tail`;
- a 10-byte pwrite under a 5-byte file limit returned 5 and was accepted.

After:
- shorter content becomes exactly `new` and empty content truncates to zero;
- the same 5/10 write returns `StatusFileWriteError`, leaves the partial five-byte file, and suppresses success text;
- open and `/dev/full` errors follow the same response and cleanup path;
- success and error callbacks both observe fd `-1` with intact buffer/count.

## Validation

- strict C++11 production compile with `-Wall -Wextra -Wpedantic -Werror`
- strict directly instrumented ASan + UBSan + LSan integration build: 3/3 passed
- focused file server suite passed with no skips
- complete CTest suite: 34/34 passed
- final library rebuilt before the complete suite
- `git diff --check`

Stacked on #329. Implements #328.