### PR TITLE
fix(fileutil): bound mutations and report failures (#331)

### DIFF
--- a/src/util/FileUtil.cc
+++ b/src/util/FileUtil.cc
@@ -1,33 +1,254 @@
-#include <sys/stat.h>
+#include <algorithm>
+#include <cerrno>
+#include <cstdint>
 #include <cstring>
-#include <fstream>
-#include <vector>
-#include <random>
 #include <dirent.h>
+#include <fcntl.h>
+#include <fstream>
+#include <limits>
+#include <random>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
-#include <errno.h>
+#include <vector>
+
 #include "FileUtil.h"
 #include "ErrorCode.h"
 #include "PathUtil.h"
 
 using namespace wfrest;
 
+namespace
+{
+
+const int k_directory_open_flags =
+    O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC;
+
+bool ensure_directory(const std::string &path)
+{
+    if (mkdir(path.c_str(), 0755) == 0)
+        return true;
+    if (errno != EEXIST)
+        return false;
+
+    struct stat metadata;
+    return stat(path.c_str(), &metadata) == 0 &&
+           S_ISDIR(metadata.st_mode);
+}
+
+std::string normalize_directory_path(const std::string &path)
+{
+    const bool absolute = !path.empty() && path.front() == '/';
+    std::vector<std::string> components;
+    size_t cursor = 0;
+    while (cursor < path.size())
+    {
+        while (cursor < path.size() && path[cursor] == '/')
+            ++cursor;
+        if (cursor == path.size())
+            break;
+
+        const size_t begin = cursor;
+        while (cursor < path.size() && path[cursor] != '/')
+            ++cursor;
+        const std::string component = path.substr(begin, cursor - begin);
+        if (component == ".")
+            continue;
+        if (component == "..")
+        {
+            if (!components.empty() && components.back() != "..")
+                components.pop_back();
+            else if (!absolute)
+                components.push_back(component);
+            continue;
+        }
+        components.push_back(component);
+    }
+
+    std::string normalized = absolute ? "/" : "";
+    for (const std::string &component : components)
+    {
+        if (!normalized.empty() && normalized.back() != '/')
+            normalized.push_back('/');
+        normalized += component;
+    }
+    if (normalized.empty())
+        return absolute ? "/" : ".";
+    return normalized;
+}
+
+int open_directory_path_nofollow(const std::string &path)
+{
+    if (path.empty())
+    {
+        errno = EINVAL;
+        return -1;
+    }
+
+    const bool absolute = path.front() == '/';
+    int current_fd = open(absolute ? "/" : ".", k_directory_open_flags);
+    if (current_fd < 0)
+        return -1;
+
+    size_t cursor = 0;
+    while (cursor < path.size())
+    {
+        while (cursor < path.size() && path[cursor] == '/')
+            ++cursor;
+        if (cursor == path.size())
+            break;
+
+        const size_t begin = cursor;
+        while (cursor < path.size() && path[cursor] != '/')
+            ++cursor;
+        const std::string component = path.substr(begin, cursor - begin);
+        if (component == ".")
+            continue;
+
+        const int next_fd = openat(current_fd, component.c_str(),
+                                   k_directory_open_flags);
+        if (next_fd < 0)
+        {
+            close(current_fd);
+            return -1;
+        }
+        if (close(current_fd) != 0)
+        {
+            close(next_fd);
+            return -1;
+        }
+        current_fd = next_fd;
+    }
+
+    return current_fd;
+}
+
+bool descriptor_matches_path(const struct stat &metadata,
+                             const std::string &path,
+                             bool *matches)
+{
+    *matches = false;
+    const int fd = open_directory_path_nofollow(path);
+    if (fd < 0)
+        return false;
+
+    struct stat other;
+    const bool inspected = fstat(fd, &other) == 0;
+    const bool closed = close(fd) == 0;
+    if (!inspected || !closed)
+        return false;
+
+    *matches = metadata.st_dev == other.st_dev &&
+               metadata.st_ino == other.st_ino;
+    return true;
+}
+
+bool remove_directory_contents(int fd, dev_t root_device)
+{
+    DIR *directory = fdopendir(fd);
+    if (directory == nullptr)
+    {
+        close(fd);
+        return false;
+    }
+
+    const int parent_fd = dirfd(directory);
+    bool success = parent_fd >= 0;
+    while (success)
+    {
+        errno = 0;
+        struct dirent *entry = readdir(directory);
+        if (entry == nullptr)
+        {
+            if (errno != 0)
+                success = false;
+            break;
+        }
+
+        if (strcmp(entry->d_name, ".") == 0 ||
+            strcmp(entry->d_name, "..") == 0)
+        {
+            continue;
+        }
+
+        struct stat metadata;
+        if (fstatat(parent_fd, entry->d_name, &metadata,
+                    AT_SYMLINK_NOFOLLOW) != 0)
+        {
+            success = false;
+            break;
+        }
+
+        if (S_ISDIR(metadata.st_mode))
+        {
+            if (metadata.st_dev != root_device)
+            {
+                success = false;
+                break;
+            }
+
+            const int child_fd = openat(parent_fd, entry->d_name,
+                                        k_directory_open_flags);
+            if (child_fd < 0)
+            {
+                success = false;
+                break;
+            }
+
+            struct stat opened_metadata;
+            if (fstat(child_fd, &opened_metadata) != 0 ||
+                opened_metadata.st_dev != metadata.st_dev ||
+                opened_metadata.st_ino != metadata.st_ino)
+            {
+                close(child_fd);
+                success = false;
+                break;
+            }
+
+            if (!remove_directory_contents(child_fd, root_device) ||
+                unlinkat(parent_fd, entry->d_name, AT_REMOVEDIR) != 0)
+            {
+                success = false;
+                break;
+            }
+        }
+        else if (unlinkat(parent_fd, entry->d_name, 0) != 0)
+        {
+            success = false;
+            break;
+        }
+    }
+
+    if (closedir(directory) != 0)
+        success = false;
+    return success;
+}
+
+} // namespace
+
 int FileUtil::size(const std::string &path, size_t *size)
 {
-    // https://linux.die.net/man/2/stat
-    struct stat st;
-    memset(&st, 0, sizeof st);
-    int ret = stat(path.c_str(), &st);
-    int status = StatusOK;
-    if(ret == -1)
+    if (size == nullptr)
+        return StatusFileReadError;
+    *size = 0;
+
+    struct stat metadata;
+    if (stat(path.c_str(), &metadata) != 0)
     {
-        *size = 0;
-        status = StatusNotFound;
-    } else
-    {
-        *size = st.st_size;
+        return errno == ENOENT || errno == ENOTDIR
+                   ? StatusNotFound
+                   : StatusFileReadError;
     }
-    return status;
+    if (!S_ISREG(metadata.st_mode) || metadata.st_size < 0 ||
+        static_cast<uintmax_t>(metadata.st_size) >
+            static_cast<uintmax_t>(std::numeric_limits<size_t>::max()))
+    {
+        return StatusFileReadError;
+    }
+
+    *size = static_cast<size_t>(metadata.st_size);
+    return StatusOK;
 }
 
 bool FileUtil::file_exists(const std::string &path)
@@ -37,82 +258,93 @@ bool FileUtil::file_exists(const std::string &path)
 
 bool FileUtil::create_directories(const std::string &path)
 {
-    std::string current_path;
-    std::string delimiter = "/";
-    size_t pos = 0;
-    std::string token;
-    std::string str = path;
-    
-    while ((pos = str.find(delimiter)) != std::string::npos) {
-        token = str.substr(0, pos);
-        current_path += token + delimiter;
-        if (!current_path.empty()) {
-            // 创建目录，忽略已存在的情况
-            mkdir(current_path.c_str(), 0755);
-        }
-        str.erase(0, pos + delimiter.length());
+    if (path.empty())
+        return false;
+
+    const bool absolute = path.front() == '/';
+    std::string current_path = absolute ? "/" : "";
+    bool has_component = false;
+    size_t cursor = 0;
+    while (cursor < path.size())
+    {
+        while (cursor < path.size() && path[cursor] == '/')
+            ++cursor;
+        if (cursor == path.size())
+            break;
+
+        const size_t begin = cursor;
+        while (cursor < path.size() && path[cursor] != '/')
+            ++cursor;
+        const std::string component = path.substr(begin, cursor - begin);
+
+        if (!current_path.empty() && current_path.back() != '/')
+            current_path.push_back('/');
+        current_path += component;
+        has_component = true;
+        if (!ensure_directory(current_path))
+            return false;
     }
-    
-    if (!str.empty()) {
-        current_path += str;
-        return mkdir(current_path.c_str(), 0755) == 0 || errno == EEXIST;
-    }
-    
+
+    if (!has_component)
+        return absolute && ensure_directory("/");
     return true;
 }
 
 bool FileUtil::remove_directory(const std::string &path)
 {
-    DIR* d = opendir(path.c_str());
-    if (!d) {
+    const std::string normalized_path = normalize_directory_path(path);
+    const int root_fd = open_directory_path_nofollow(path);
+    if (root_fd < 0)
+        return false;
+
+    struct stat root_metadata;
+    if (fstat(root_fd, &root_metadata) != 0 ||
+        !S_ISDIR(root_metadata.st_mode))
+    {
+        close(root_fd);
         return false;
     }
-    
-    struct dirent* dir;
-    while ((dir = readdir(d)) != NULL) {
-        if (strcmp(dir->d_name, ".") == 0 || strcmp(dir->d_name, "..") == 0) {
-            continue;
-        }
-        
-        std::string full_path = path + "/" + dir->d_name;
-        struct stat s;
-        if (stat(full_path.c_str(), &s) == 0) {
-            if (S_ISDIR(s.st_mode)) {
-                remove_directory(full_path);
-            } else {
-                unlink(full_path.c_str());
-            }
-        }
+
+    bool is_root = false;
+    bool is_current = false;
+    if (!descriptor_matches_path(root_metadata, "/", &is_root) ||
+        !descriptor_matches_path(root_metadata, ".", &is_current) ||
+        is_root || is_current)
+    {
+        close(root_fd);
+        return false;
     }
-    
-    closedir(d);
-    return rmdir(path.c_str()) == 0;
+
+    if (!remove_directory_contents(root_fd, root_metadata.st_dev))
+        return false;
+    return rmdir(normalized_path.c_str()) == 0;
 }
 
-bool FileUtil::create_file_with_size(const std::string &path, size_t size_bytes)
+bool FileUtil::create_file_with_size(const std::string &path,
+                                     size_t size_bytes)
 {
     std::ofstream file(path.c_str(), std::ios::binary);
-    if (!file) {
+    if (!file)
         return false;
-    }
 
-    // 生成随机内容
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_int_distribution<> distrib(32, 126); // 可打印ASCII字符
+    std::random_device random_device;
+    std::mt19937 generator(random_device());
+    std::uniform_int_distribution<> distribution(32, 126);
 
     std::vector<char> buffer(4096);
     size_t remaining = size_bytes;
+    while (remaining > 0)
+    {
+        const size_t chunk_size = std::min(remaining, buffer.size());
+        for (size_t i = 0; i < chunk_size; ++i)
+            buffer[i] = static_cast<char>(distribution(generator));
 
-    while (remaining > 0) {
-        size_t chunk_size = std::min(remaining, buffer.size());
-        for (size_t i = 0; i < chunk_size; ++i) {
-            buffer[i] = static_cast<char>(distrib(gen));
-        }
-        file.write(buffer.data(), chunk_size);
+        file.write(buffer.data(), static_cast<std::streamsize>(chunk_size));
+        if (!file)
+            return false;
         remaining -= chunk_size;
     }
 
     file.close();
-    return true;
+    return !file.fail();
 }

--- a/test/FileUtil_unittest.cc
+++ b/test/FileUtil_unittest.cc
@@ -1,51 +1,191 @@
 #include <gtest/gtest.h>
+
+#include <algorithm>
+#include <fcntl.h>
 #include <fstream>
+#include <iterator>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "wfrest/ErrorCode.h"
 #include "wfrest/FileUtil.h"
 #include "FileTestUtil.h"
 
 using namespace wfrest;
 
-TEST(FileUtil, size)
+namespace
 {
-    std::string file_path = "./example.txt";
-    // 1. Write a sample text first
-    bool write_ok = FileTestUtil::write_file(file_path, "Writing this to a file.\n");
-    EXPECT_EQ(write_ok, true);
 
-    // 2. Then we get the file size
-    size_t sample_size;
-    int ret = FileUtil::size(file_path, &sample_size);
-    EXPECT_TRUE(ret == 0);
-    EXPECT_EQ(sample_size, 24);
-
-    // 3. At last we delete this tmp file
-    std::remove(file_path.c_str());
-    EXPECT_FALSE(FileUtil::file_exists(file_path));
+std::string test_root(const std::string &name)
+{
+    return "/tmp/wfrest-fileutil-" + name + "-" +
+           std::to_string(getpid());
 }
 
-TEST(FileUtil, file_exists)
+bool path_exists(const std::string &path)
 {
-    std::string file_path = "./example.md";
-    bool write_ok = FileTestUtil::write_file(file_path, "Writing this to a file.\n");
-    EXPECT_EQ(write_ok, true);
-
-    EXPECT_TRUE(FileUtil::file_exists(file_path));
-
-    std::remove(file_path.c_str());
-    EXPECT_FALSE(FileUtil::file_exists(file_path));
+    struct stat metadata;
+    return lstat(path.c_str(), &metadata) == 0;
 }
 
-TEST(FileUtil, file_exists_txt)
+bool is_directory(const std::string &path)
 {
-    std::string file_path = "./example.txt";
-    bool write_ok = FileTestUtil::write_file(file_path, "Writing this to a file.\n");
-    EXPECT_EQ(write_ok, true);
-
-    EXPECT_TRUE(FileUtil::file_exists(file_path));
-
-    std::remove(file_path.c_str());
-    EXPECT_FALSE(FileUtil::file_exists(file_path));
+    struct stat metadata;
+    return stat(path.c_str(), &metadata) == 0 &&
+           S_ISDIR(metadata.st_mode);
 }
 
+off_t file_size(const std::string &path)
+{
+    struct stat metadata;
+    return stat(path.c_str(), &metadata) == 0 ? metadata.st_size : -1;
+}
 
+std::string read_file(const std::string &path)
+{
+    std::ifstream file(path, std::ios::binary);
+    return std::string(std::istreambuf_iterator<char>(file),
+                       std::istreambuf_iterator<char>());
+}
 
+} // namespace
+
+TEST(FileUtil, size_classifies_results_without_invalid_access)
+{
+    const std::string root = test_root("size");
+    ASSERT_TRUE(FileUtil::create_directories(root));
+    const std::string file = root + "/regular.txt";
+    ASSERT_TRUE(FileTestUtil::write_file(file, "Writing this to a file.\n"));
+
+    size_t result = 99;
+    EXPECT_TRUE(FileUtil::file_exists(file));
+    EXPECT_FALSE(FileUtil::file_exists(root));
+    EXPECT_EQ(FileUtil::size(file, &result), StatusOK);
+    EXPECT_EQ(result, 24U);
+
+    result = 99;
+    EXPECT_EQ(FileUtil::size(root + "/missing", &result), StatusNotFound);
+    EXPECT_EQ(result, 0U);
+
+    result = 99;
+    EXPECT_EQ(FileUtil::size(root, &result), StatusFileReadError);
+    EXPECT_EQ(result, 0U);
+    EXPECT_EQ(FileUtil::size(file, nullptr), StatusFileReadError);
+
+    const std::string link = root + "/regular-link";
+    ASSERT_EQ(symlink(file.c_str(), link.c_str()), 0);
+    result = 0;
+    EXPECT_EQ(FileUtil::size(link, &result), StatusOK);
+    EXPECT_EQ(result, 24U);
+
+    EXPECT_TRUE(FileUtil::remove_directory(root));
+    EXPECT_FALSE(path_exists(root));
+}
+
+TEST(FileUtil, create_directories_checks_every_component)
+{
+    const std::string root = test_root("mkdir");
+    const std::string nested = root + "//a/b///c/";
+    const std::string relative_root =
+        "./wfrest-fileutil-relative-" + std::to_string(getpid());
+    const std::string relative_nested = relative_root + "/a/b/";
+    EXPECT_FALSE(FileUtil::create_directories(""));
+    EXPECT_TRUE(FileUtil::create_directories("/"));
+    ASSERT_TRUE(FileUtil::create_directories(nested));
+    ASSERT_TRUE(FileUtil::create_directories(relative_nested));
+    EXPECT_TRUE(is_directory(root + "/a/b/c"));
+    EXPECT_TRUE(is_directory(relative_nested));
+    EXPECT_TRUE(FileUtil::create_directories(nested));
+
+    const std::string blocker = root + "/blocker";
+    ASSERT_TRUE(FileTestUtil::write_file(blocker, "not a directory"));
+    EXPECT_FALSE(FileUtil::create_directories(blocker));
+    EXPECT_FALSE(FileUtil::create_directories(blocker + "/"));
+    EXPECT_FALSE(FileUtil::create_directories(blocker + "/child"));
+
+    EXPECT_TRUE(FileUtil::remove_directory(root));
+    EXPECT_TRUE(FileUtil::remove_directory(relative_root));
+    EXPECT_FALSE(path_exists(root));
+    EXPECT_FALSE(path_exists(relative_root));
+}
+
+TEST(FileUtil, remove_directory_never_follows_symlinks)
+{
+    const std::string root = test_root("remove");
+    const std::string target = root + "/target";
+    const std::string nested = target + "/a/b";
+    const std::string outside = root + "/outside";
+    ASSERT_TRUE(FileUtil::create_directories(nested));
+    ASSERT_TRUE(FileUtil::create_directories(outside));
+    ASSERT_TRUE(FileTestUtil::write_file(nested + "/inside.txt", "inside"));
+    const std::string outside_file = outside + "/keep.txt";
+    ASSERT_TRUE(FileTestUtil::write_file(outside_file, "keep"));
+
+    const std::string child_link = target + "/escape";
+    ASSERT_EQ(symlink(outside.c_str(), child_link.c_str()), 0);
+    const std::string root_link = root + "/outside-link";
+    ASSERT_EQ(symlink(outside.c_str(), root_link.c_str()), 0);
+
+    EXPECT_FALSE(FileUtil::remove_directory(root_link));
+    EXPECT_FALSE(FileUtil::remove_directory(root_link + "/."));
+    EXPECT_TRUE(path_exists(outside_file));
+    EXPECT_EQ(read_file(outside_file), "keep");
+
+    EXPECT_TRUE(FileUtil::remove_directory(target + "/./"));
+    EXPECT_FALSE(path_exists(target));
+    EXPECT_TRUE(path_exists(outside_file));
+    EXPECT_EQ(read_file(outside_file), "keep");
+    EXPECT_FALSE(FileUtil::remove_directory(outside_file));
+    EXPECT_FALSE(FileUtil::remove_directory(root + "/missing"));
+
+    unlink(root_link.c_str());
+    EXPECT_TRUE(FileUtil::remove_directory(root));
+    EXPECT_FALSE(path_exists(root));
+}
+
+TEST(FileUtil, remove_directory_rejects_current_directory)
+{
+    const std::string root = test_root("current");
+    ASSERT_TRUE(FileUtil::create_directories(root));
+    ASSERT_TRUE(FileTestUtil::write_file(root + "/sentinel", "keep"));
+
+    const int original_cwd = open(".", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    ASSERT_GE(original_cwd, 0);
+    ASSERT_EQ(chdir(root.c_str()), 0);
+    EXPECT_FALSE(FileUtil::remove_directory("."));
+    EXPECT_TRUE(path_exists("./sentinel"));
+    ASSERT_EQ(fchdir(original_cwd), 0);
+    ASSERT_EQ(close(original_cwd), 0);
+
+    EXPECT_TRUE(FileUtil::remove_directory(root));
+}
+
+TEST(FileUtil, create_file_with_size_reports_complete_writes)
+{
+    const std::string root = test_root("generate");
+    ASSERT_TRUE(FileUtil::create_directories(root));
+    const std::string path = root + "/generated.bin";
+
+    ASSERT_TRUE(FileUtil::create_file_with_size(path, 9000));
+    EXPECT_EQ(file_size(path), 9000);
+    const std::string content = read_file(path);
+    ASSERT_EQ(content.size(), 9000U);
+    EXPECT_TRUE(std::all_of(content.begin(), content.end(), [](char ch)
+    {
+        const unsigned char byte = static_cast<unsigned char>(ch);
+        return byte >= 32 && byte <= 126;
+    }));
+
+    EXPECT_TRUE(FileUtil::create_file_with_size(path, 0));
+    EXPECT_EQ(file_size(path), 0);
+    EXPECT_FALSE(FileUtil::create_file_with_size(
+        root + "/missing/child.bin", 1));
+    EXPECT_FALSE(FileUtil::create_file_with_size(root, 1));
+    if (access("/dev/full", W_OK) == 0)
+    {
+        EXPECT_FALSE(FileUtil::create_file_with_size("/dev/full", 4096));
+    }
+
+    EXPECT_TRUE(FileUtil::remove_directory(root));
+}


### PR DESCRIPTION
## Why

`FileUtil` ignored intermediate mkdir, child removal, stream write, and close failures. Its `stat`-based recursive delete also followed directory symlinks: a controlled tree deleted an external sibling file before returning false.

## Plan implemented

1. Classify size errors with null, type, sign, and range checks.
2. Verify every mkdir component and accept `EEXIST` only for a directory.
3. Open every removal root component with `openat(..., O_NOFOLLOW)`.
4. Walk entries fd-relatively with `fstatat`, `openat`, `fdopendir`, and `unlinkat`.
5. Unlink symlinks without traversal, verify child inode identity, refuse device boundaries, and guard root/current directory.
6. Propagate enumeration, open, recursive removal, unlink, close, and final rmdir failures.
7. Check every generated-file write and final stream close.
8. Add focused normal, conflict, symlink-escape, current-directory, `/dev/full`, and range tests.

## Before and after probe

- child directory symlink: external file deleted -> external file preserved and link removed;
- regular `blocker/` mkdir: true -> false;
- `/dev/full` generated file: true -> false.

## Validation

- strict C++11 production compile with `-Wall -Wextra -Wpedantic -Werror`
- directly instrumented ASan + UBSan + LSan suite: 5/5 passed
- focused `FileUtil_unittest`: passed
- complete CTest suite: 34/34 passed
- original controlled three-case probe now reports safe/false results
- `git diff --check`

Stacked on #332. Implements #331.