### PR TITLE
fix(http): validate response headers and framing (#334)

### DIFF
--- a/src/core/HttpHeaderUtil.h
+++ b/src/core/HttpHeaderUtil.h
@@ -1,0 +1,201 @@
+#ifndef WFREST_HTTPHEADERUTIL_H_
+#define WFREST_HTTPHEADERUTIL_H_
+
+#include <cstddef>
+#include <string>
+
+namespace wfrest
+{
+namespace detail
+{
+
+inline unsigned char header_ascii_lower(unsigned char ch)
+{
+    if (ch >= 'A' && ch <= 'Z')
+        return static_cast<unsigned char>(ch + ('a' - 'A'));
+    return ch;
+}
+
+inline bool header_ascii_iequals(const std::string &value,
+                                 const char *expected)
+{
+    size_t cursor = 0;
+    while (cursor < value.size() && expected[cursor] != '\0')
+    {
+        if (header_ascii_lower(static_cast<unsigned char>(value[cursor])) !=
+            header_ascii_lower(static_cast<unsigned char>(expected[cursor])))
+        {
+            return false;
+        }
+        ++cursor;
+    }
+    return cursor == value.size() && expected[cursor] == '\0';
+}
+
+inline bool is_header_token_char(unsigned char ch)
+{
+    if ((ch >= '0' && ch <= '9') ||
+        (ch >= 'A' && ch <= 'Z') ||
+        (ch >= 'a' && ch <= 'z'))
+    {
+        return true;
+    }
+
+    switch (ch)
+    {
+        case '!':
+        case '#':
+        case '$':
+        case '%':
+        case '&':
+        case '\'':
+        case '*':
+        case '+':
+        case '-':
+        case '.':
+        case '^':
+        case '_':
+        case '`':
+        case '|':
+        case '~':
+            return true;
+        default:
+            return false;
+    }
+}
+
+inline bool is_valid_response_header_name(const std::string &name)
+{
+    if (name.empty())
+        return false;
+    for (unsigned char ch : name)
+    {
+        if (!is_header_token_char(ch))
+            return false;
+    }
+    return true;
+}
+
+inline bool is_valid_response_header_value(const std::string &value)
+{
+    for (unsigned char ch : value)
+    {
+        if (ch != '\t' && (ch < ' ' || ch == 0x7f))
+            return false;
+    }
+    return true;
+}
+
+inline bool is_framework_managed_response_header(const std::string &name)
+{
+    return header_ascii_iequals(name, "Content-Length") ||
+           header_ascii_iequals(name, "Transfer-Encoding");
+}
+
+inline bool is_application_response_header(const std::string &name,
+                                           const std::string &value)
+{
+    return is_valid_response_header_name(name) &&
+           is_valid_response_header_value(value) &&
+           !is_framework_managed_response_header(name);
+}
+
+template<typename HeaderMap>
+void sanitize_application_response_headers(HeaderMap *headers)
+{
+    auto current = headers->begin();
+    while (current != headers->end())
+    {
+        if (is_application_response_header(current->first, current->second))
+        {
+            ++current;
+        }
+        else
+        {
+            const auto invalid = current++;
+            headers->erase(invalid);
+        }
+    }
+}
+
+inline bool is_ows_byte(char ch)
+{
+    return ch == ' ' || ch == '\t';
+}
+
+inline bool is_token_range(const std::string &value,
+                           size_t begin,
+                           size_t end)
+{
+    if (begin == end)
+        return false;
+    for (size_t cursor = begin; cursor < end; ++cursor)
+    {
+        if (!is_header_token_char(
+                static_cast<unsigned char>(value[cursor])))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+inline bool header_ascii_range_iequals(const std::string &value,
+                                       size_t begin,
+                                       size_t end,
+                                       const char *expected)
+{
+    size_t cursor = begin;
+    size_t expected_cursor = 0;
+    while (cursor < end && expected[expected_cursor] != '\0')
+    {
+        if (header_ascii_lower(static_cast<unsigned char>(value[cursor])) !=
+            header_ascii_lower(
+                static_cast<unsigned char>(expected[expected_cursor])))
+        {
+            return false;
+        }
+        ++cursor;
+        ++expected_cursor;
+    }
+    return cursor == end && expected[expected_cursor] == '\0';
+}
+
+inline bool is_json_response_content_type(const std::string &value)
+{
+    if (!is_valid_response_header_value(value))
+        return false;
+
+    const size_t semicolon = value.find(';');
+    size_t begin = 0;
+    size_t end = semicolon == std::string::npos
+                     ? value.size()
+                     : semicolon;
+    while (begin < end && is_ows_byte(value[begin]))
+        ++begin;
+    while (end > begin && is_ows_byte(value[end - 1]))
+        --end;
+
+    const size_t slash = value.find('/', begin);
+    if (slash == std::string::npos || slash >= end ||
+        value.find('/', slash + 1) < end ||
+        !is_token_range(value, begin, slash) ||
+        !is_token_range(value, slash + 1, end))
+    {
+        return false;
+    }
+
+    const size_t subtype_begin = slash + 1;
+    if (header_ascii_range_iequals(value, subtype_begin, end, "json"))
+        return true;
+
+    const size_t suffix_size = 5;
+    return end - subtype_begin >= suffix_size &&
+           header_ascii_range_iequals(value, end - suffix_size, end,
+                                      "+json");
+}
+
+} // namespace detail
+} // namespace wfrest
+
+#endif // WFREST_HTTPHEADERUTIL_H_

--- a/src/core/HttpMsg.cc
+++ b/src/core/HttpMsg.cc
@@ -15,6 +15,7 @@
 #include "FileUtil.h"
 #include "HttpServerTask.h"
 #include "CodeUtil.h"
+#include "HttpHeaderUtil.h"
 #include "PushWriteUtil.h"
 
 using namespace protocol;
@@ -1068,13 +1069,10 @@ void push_func(WFCounterTask *push_task)
 
 std::string HttpResp::construct_push_header()
 {
+    detail::sanitize_application_response_headers(&headers);
     std::string http_header;
     http_header.reserve(128);
     http_header.append("HTTP/1.1 200 OK\r\n");
-    if (headers.find("Transfer-Encoding") != headers.end())
-    {
-        headers.erase("Transfer-Encoding");
-    }
     for (auto it = headers.begin(); it != headers.end(); it++)
     {
         const auto &key = it->first;
@@ -1193,10 +1191,12 @@ void HttpResp::Save(const std::string &file_dst, std::string &&content,
 
 void HttpResp::Json(const wfrest::Json &json)
 {
-    if (this->headers.count("Content-Type") == 0)
+    const auto content_type = this->headers.find("Content-Type");
+    if (content_type == this->headers.end() ||
+        !detail::is_json_response_content_type(content_type->second))
+    {
         this->headers["Content-Type"] = "application/json";
-    else
-        this->headers["Content-Type"].insert(0, "application/json; ");
+    }
     this->String(json.dump());
 }
 
@@ -1207,10 +1207,12 @@ void HttpResp::Json(const std::string &str)
         this->Error(StatusJsonInvalid);
         return;
     }
-    if (this->headers.count("Content-Type") == 0)
+    const auto content_type = this->headers.find("Content-Type");
+    if (content_type == this->headers.end() ||
+        !detail::is_json_response_content_type(content_type->second))
+    {
         this->headers["Content-Type"] = "application/json";
-    else
-        this->headers["Content-Type"].insert(0, "application/json; ");
+    }
     this->String(str);
 }
 
@@ -1365,8 +1367,29 @@ void HttpResp::Redis(const std::string &url, const std::string &command,
 
 void HttpResp::Redirect(const std::string& location, int status_code)
 {
-    this->headers["Location"] = location;
+    this->headers.erase("Location");
+    this->add_header("Location", location);
     this->set_status(status_code);
+}
+
+void HttpResp::add_header(const std::string &key, const std::string &val)
+{
+    if (detail::is_application_response_header(key, val))
+        headers[key] = val;
+}
+
+bool HttpResp::add_header_pair(const std::string &key,
+                               const std::string &val)
+{
+    return detail::is_application_response_header(key, val) &&
+           protocol::HttpResponse::add_header_pair(key, val);
+}
+
+bool HttpResp::set_header_pair(const std::string &key,
+                               const std::string &val)
+{
+    return detail::is_application_response_header(key, val) &&
+           protocol::HttpResponse::set_header_pair(key, val);
 }
 
 void HttpResp::add_task(SubTask *task)

--- a/src/core/HttpMsg.h
+++ b/src/core/HttpMsg.h
@@ -289,10 +289,11 @@ public:
 
     void add_task(SubTask *task);
 
-    void add_header(const std::string &key, const std::string &val)
-    {
-        headers[key] = val;
-    }
+    void add_header(const std::string &key, const std::string &val);
+
+    bool add_header_pair(const std::string &key, const std::string &val);
+
+    bool set_header_pair(const std::string &key, const std::string &val);
 
     void CachedFile(const std::string &path);
 

--- a/src/core/HttpServerTask.cc
+++ b/src/core/HttpServerTask.cc
@@ -5,6 +5,7 @@
 
 #include "HttpServerTask.h"
 #include "HttpServer.h"
+#include "HttpHeaderUtil.h"
 #include "StrUtil.h"
 
 using namespace protocol;
@@ -59,6 +60,7 @@ CommMessageOut *HttpServerTask::message_out()
     HttpResp *resp = this->get_resp();
 
     std::map<std::string, std::string, MapStringCaseLess> &headers = resp->headers;
+    detail::sanitize_application_response_headers(&headers);
     // content type
     if(headers.find("Content-Type") == headers.end())
     {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,6 +71,7 @@ set(UNIT_TEST_LIST
 	UriUtil_unittest
 	HttpContent_unittest
 	HttpMsg_unittest
+	HttpHeaderUtil_unittest
 	PushWriteUtil_unittest
 )
 
@@ -99,6 +100,7 @@ set(SERVER_UNIT_TEST_LIST
 	compute_test
 	send_form_test
 	multipart_test
+	header_test
 	push_test
 	cookie_test
 	blueprint_test

--- a/test/HttpHeaderUtil_unittest.cc
+++ b/test/HttpHeaderUtil_unittest.cc
@@ -1,0 +1,93 @@
+#include <gtest/gtest.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "wfrest/HttpMsg.h"
+#include "workflow/HttpUtil.h"
+#include "../src/core/HttpHeaderUtil.h"
+
+using namespace wfrest;
+
+TEST(HttpHeaderUtil, validates_names_and_values_by_byte)
+{
+    using detail::is_valid_response_header_name;
+    using detail::is_valid_response_header_value;
+
+    EXPECT_TRUE(is_valid_response_header_name(
+        "AZaz09!#$%&'*+-.^_`|~"));
+    for (const std::string &invalid : {
+             std::string(), std::string("Bad Name"), std::string("Bad\tName"),
+             std::string("Bad:Name"), std::string("Bad\rName"),
+             std::string("Bad\nName"), std::string("Bad\0Name", 8),
+             std::string("Bad\x7fName", 8), std::string("X-\x80", 3)})
+    {
+        EXPECT_FALSE(is_valid_response_header_name(invalid));
+    }
+
+    EXPECT_TRUE(is_valid_response_header_value(""));
+    EXPECT_TRUE(is_valid_response_header_value("visible\tvalue"));
+    EXPECT_TRUE(is_valid_response_header_value(std::string("obs-\x80", 5)));
+    for (int byte = 0; byte < 32; ++byte)
+    {
+        if (byte == '\t')
+            continue;
+        EXPECT_FALSE(is_valid_response_header_value(
+            std::string(1, static_cast<char>(byte))));
+    }
+    EXPECT_FALSE(is_valid_response_header_value(std::string(1, '\x7f')));
+}
+
+TEST(HttpHeaderUtil, removes_invalid_and_framework_managed_entries)
+{
+    std::map<std::string, std::string> headers = {
+        {"X-Safe", "value"},
+        {"Bad Name", "value"},
+        {"X-Bad", "safe\r\nX-Injected: yes"},
+        {"content-length", "1"},
+        {"TRANSFER-ENCODING", "chunked"}
+    };
+
+    detail::sanitize_application_response_headers(&headers);
+    ASSERT_EQ(headers.size(), 1U);
+    EXPECT_EQ(headers.at("X-Safe"), "value");
+}
+
+TEST(HttpHeaderUtil, recognizes_json_media_types)
+{
+    using detail::is_json_response_content_type;
+    EXPECT_TRUE(is_json_response_content_type("application/json"));
+    EXPECT_TRUE(is_json_response_content_type(
+        " Application/Problem+JSON \t; charset=utf-8"));
+    EXPECT_TRUE(is_json_response_content_type("text/json; charset=utf-8"));
+
+    EXPECT_FALSE(is_json_response_content_type(""));
+    EXPECT_FALSE(is_json_response_content_type("charset=utf-8"));
+    EXPECT_FALSE(is_json_response_content_type("text/plain"));
+    EXPECT_FALSE(is_json_response_content_type("application/json/text"));
+    EXPECT_FALSE(is_json_response_content_type("application/json text"));
+    EXPECT_FALSE(is_json_response_content_type(
+        "application/json\r\nX-Injected: yes"));
+}
+
+TEST(HttpHeaderUtil, response_wrappers_reject_unsafe_and_framing_fields)
+{
+    HttpResp response;
+    response.add_header("X-Safe", "first");
+    response.add_header("X-Safe", "bad\r\nX-Injected: yes");
+    response.add_header("Bad Name", "value");
+    response.add_header("Content-Length", "1");
+    ASSERT_EQ(response.headers.size(), 1U);
+    EXPECT_EQ(response.headers.at("X-Safe"), "first");
+
+    EXPECT_TRUE(response.add_header_pair("X-Low", "value"));
+    EXPECT_TRUE(response.set_header_pair("X-Low", "updated"));
+    EXPECT_FALSE(response.add_header_pair("X-Bad", "value\nnext"));
+    EXPECT_FALSE(response.set_header_pair("Transfer-Encoding", "chunked"));
+
+    protocol::HttpHeaderMap parsed(&response);
+    EXPECT_EQ(parsed.get("X-Low"), "updated");
+    EXPECT_TRUE(parsed.get("X-Bad").empty());
+    EXPECT_TRUE(parsed.get("Transfer-Encoding").empty());
+}

--- a/test/HttpServer/header_test.cc
+++ b/test/HttpServer/header_test.cc
@@ -1,0 +1,134 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "wfrest/HttpServer.h"
+#include "wfrest/Json.h"
+#include "workflow/WFFacilities.h"
+#include "../ClientUtil.h"
+
+using namespace protocol;
+using namespace wfrest;
+
+namespace
+{
+
+std::string response_body(WFHttpTask *task)
+{
+    const void *body = nullptr;
+    size_t size = 0;
+    if (!task->get_resp()->get_parsed_body(&body, &size) || size == 0)
+        return "";
+    return std::string(static_cast<const char *>(body), size);
+}
+
+} // namespace
+
+TEST(HttpServer, validates_response_headers_and_framing)
+{
+    HttpServer server;
+    WFFacilities::WaitGroup wait_group(5);
+
+    server.GET("/sanitize", [](const HttpReq *, HttpResp *resp)
+    {
+        resp->add_header("X-Safe", "yes");
+        resp->add_header("X-User", "safe\r\nX-Injected: yes");
+        resp->add_header("Bad Name", "value");
+        resp->headers["X-Direct"] = "safe\r\nX-Direct-Injected: yes";
+        resp->headers["Bad:Direct"] = "value";
+        resp->String("body");
+    });
+    server.GET("/framing", [](const HttpReq *, HttpResp *resp)
+    {
+        resp->headers["Content-Length"] = "1";
+        resp->headers["Transfer-Encoding"] = "chunked";
+        resp->String("abcdef");
+    });
+    server.GET("/redirect", [](const HttpReq *, HttpResp *resp)
+    {
+        resp->add_header("Location", "/previous");
+        resp->Redirect("/safe\r\nX-Redirected: yes", 302);
+    });
+    server.GET("/json", [](const HttpReq *, HttpResp *resp)
+    {
+        resp->add_header("Content-Type", "text/plain");
+        Json value;
+        value["ok"] = true;
+        resp->Json(value);
+    });
+    server.GET("/problem", [](const HttpReq *, HttpResp *resp)
+    {
+        resp->add_header("Content-Type",
+                         "application/problem+json; charset=utf-8");
+        Json value;
+        value["problem"] = true;
+        resp->Json(value);
+    });
+    ASSERT_EQ(server.start("127.0.0.1", 8888), 0);
+
+    WFHttpTask *sanitize = ClientUtil::create_http_task("sanitize");
+    sanitize->set_callback([&](WFHttpTask *task)
+    {
+        EXPECT_EQ(task->get_state(), WFT_STATE_SUCCESS);
+        HttpHeaderMap headers(task->get_resp());
+        EXPECT_EQ(headers.get("X-Safe"), "yes");
+        EXPECT_TRUE(headers.get("X-Injected").empty());
+        EXPECT_TRUE(headers.get("X-Direct-Injected").empty());
+        EXPECT_TRUE(headers.get("Bad:Direct").empty());
+        EXPECT_EQ(response_body(task), "body");
+        wait_group.done();
+    });
+    sanitize->start();
+
+    WFHttpTask *framing = ClientUtil::create_http_task("framing");
+    framing->set_callback([&](WFHttpTask *task)
+    {
+        EXPECT_EQ(task->get_state(), WFT_STATE_SUCCESS);
+        HttpHeaderMap headers(task->get_resp());
+        EXPECT_EQ(headers.get("Content-Length"), "6");
+        EXPECT_TRUE(headers.get("Transfer-Encoding").empty());
+        EXPECT_EQ(response_body(task), "abcdef");
+        wait_group.done();
+    });
+    framing->start();
+
+    WFHttpTask *redirect = WFTaskFactory::create_http_task(
+        "http://127.0.0.1:8888/redirect", 0, 2, nullptr);
+    redirect->set_callback([&](WFHttpTask *task)
+    {
+        EXPECT_EQ(task->get_state(), WFT_STATE_SUCCESS);
+        HttpHeaderMap headers(task->get_resp());
+        EXPECT_STREQ(task->get_resp()->get_status_code(), "302");
+        EXPECT_TRUE(headers.get("Location").empty());
+        EXPECT_TRUE(headers.get("X-Redirected").empty());
+        wait_group.done();
+    });
+    redirect->start();
+
+    WFHttpTask *json = ClientUtil::create_http_task("json");
+    json->set_callback([&](WFHttpTask *task)
+    {
+        EXPECT_EQ(task->get_state(), WFT_STATE_SUCCESS);
+        HttpHeaderMap headers(task->get_resp());
+        EXPECT_EQ(headers.get("Content-Type"), "application/json");
+        EXPECT_TRUE(Json::parse(response_body(task)).is_valid());
+        wait_group.done();
+    });
+    json->start();
+
+    WFHttpTask *problem = ClientUtil::create_http_task("problem");
+    problem->set_callback([&](WFHttpTask *task)
+    {
+        EXPECT_EQ(task->get_state(), WFT_STATE_SUCCESS);
+        HttpHeaderMap headers(task->get_resp());
+        EXPECT_EQ(headers.get("Content-Type"),
+                  "application/problem+json; charset=utf-8");
+        EXPECT_TRUE(Json::parse(response_body(task)).is_valid());
+        wait_group.done();
+    });
+    problem->start();
+
+    wait_group.wait();
+    server.stop();
+}

--- a/test/HttpServer/push_test.cc
+++ b/test/HttpServer/push_test.cc
@@ -21,6 +21,9 @@ TEST(HttpServer, push_stops_after_terminal_chunk)
         resp->add_header("Content-Type", "text/event-stream");
         resp->add_header("Cache-Control", "no-cache");
         resp->add_header("Connection", "keep-alive");
+        resp->headers["X-Push"] = "safe\r\nX-Push-Injected: yes";
+        resp->headers["Content-Length"] = "1";
+        resp->headers["Transfer-Encoding"] = "identity";
         resp->Push(condition, [&](std::string &body)
         {
             if (++push_calls == 1)
@@ -37,6 +40,17 @@ TEST(HttpServer, push_stops_after_terminal_chunk)
     client->set_callback([&](WFHttpTask *task)
     {
         EXPECT_EQ(task->get_state(), WFT_STATE_SUCCESS);
+        HttpHeaderMap headers(task->get_resp());
+        EXPECT_TRUE(headers.get("X-Push").empty());
+        EXPECT_TRUE(headers.get("X-Push-Injected").empty());
+        EXPECT_TRUE(headers.get("Content-Length").empty());
+        const auto transfer_encodings =
+            headers.get_strict("Transfer-Encoding");
+        EXPECT_EQ(transfer_encodings.size(), 1U);
+        if (!transfer_encodings.empty())
+        {
+            EXPECT_EQ(transfer_encodings.front(), "chunked");
+        }
         const void *body = nullptr;
         size_t body_size = 0;
         const bool parsed = task->get_resp()->get_parsed_body(&body, &body_size);


### PR DESCRIPTION
## Why

Application header bytes reached Workflow and raw Push serialization without validation. Live probes produced real CRLF-injected headers, Redirect splitting, one-byte truncation from forged Content-Length, and invalid Json Content-Type concatenation.

## Plan implemented

1. Add shared C++11 field-name, field-value, managed-framing, media-type, and map-sanitizer helpers.
2. Validate `add_header` and source-compatible add/set pair wrappers.
3. Sanitize direct public-map writes before ordinary and Push output.
4. Reserve Content-Length and Transfer-Encoding for framework framing.
5. Emit one Push chunked field and no Push Content-Length.
6. Clear old Redirect Location before validated replacement.
7. Replace non-JSON Content-Type and preserve valid json/+json media types.
8. Add direct byte/API tests plus ordinary and Push integration tests.

## Before and after live probe

- CRLF header injection: injected header -> omitted;
- Redirect injection: injected header -> omitted Location and no split;
- body `abcdef` with attempted length 1: one byte -> six bytes with computed length 6;
- Json after text/plain: `application/json; text/plain` -> `application/json`.

## Validation

- strict C++11 `HttpMsg.cc` and `HttpServerTask.cc` compile with `-Wall -Wextra -Wpedantic -Werror`
- directly instrumented ASan + UBSan + LSan utility/ordinary/Push suite: 6/6 passed
- focused Header/Json/Proxy/Push CTest: 5/5 passed
- complete CTest suite: 36/36 passed
- final four-route live probe passed
- `git diff --check`

Stacked on #335. Implements #334.