### PR TITLE
fix(multipart): own encoder tasks and finalize bodies (#337)

### DIFF
--- a/src/core/HttpContent.cc
+++ b/src/core/HttpContent.cc
@@ -1,6 +1,7 @@
 #include <strings.h>
 #include <utility>
 #include "HttpContent.h"
+#include "MultipartUtil.h"
 #include "StringPiece.h"
 #include "UriUtil.h"
 
@@ -10,50 +11,6 @@ const std::string MultiPartForm::k_default_boundary = "----WebKitFormBoundary7MA
 
 namespace
 {
-
-bool is_multipart_boundary_char(unsigned char ch)
-{
-    if ((ch >= '0' && ch <= '9') ||
-        (ch >= 'A' && ch <= 'Z') ||
-        (ch >= 'a' && ch <= 'z'))
-    {
-        return true;
-    }
-
-    switch (ch)
-    {
-        case ' ':
-        case '\'':
-        case '(':
-        case ')':
-        case '+':
-        case '_':
-        case ',':
-        case '-':
-        case '.':
-        case '/':
-        case ':':
-        case '=':
-        case '?':
-            return true;
-        default:
-            return false;
-    }
-}
-
-bool is_valid_multipart_boundary(const std::string &boundary)
-{
-    if (boundary.empty() || boundary.size() > 70 || boundary.back() == ' ')
-        return false;
-
-    for (unsigned char ch : boundary)
-    {
-        if (!is_multipart_boundary_char(ch))
-            return false;
-    }
-
-    return true;
-}
 
 bool is_ows(char ch)
 {
@@ -354,7 +311,7 @@ MultiPartForm::MultiPartForm()
 
 void MultiPartForm::set_boundary(const std::string &boundary)
 {
-    if (is_valid_multipart_boundary(boundary))
+    if (detail::is_valid_multipart_boundary(boundary))
         boundary_ = boundary;
     else
         boundary_.clear();
@@ -362,7 +319,7 @@ void MultiPartForm::set_boundary(const std::string &boundary)
 
 void MultiPartForm::set_boundary(std::string &&boundary)
 {
-    if (is_valid_multipart_boundary(boundary))
+    if (detail::is_valid_multipart_boundary(boundary))
         boundary_ = std::move(boundary);
     else
         boundary_.clear();
@@ -465,10 +422,12 @@ void MultiPartEncoder::add_file(const std::string &file_name, const std::string 
 
 void MultiPartEncoder::set_boundary(const std::string &boundary)
 {
-    boundary_ = boundary;
+    if (detail::is_valid_multipart_boundary(boundary))
+        boundary_ = boundary;
 }
 
 void MultiPartEncoder::set_boundary(std::string &&boundary) 
 {
-    boundary_ = std::move(boundary);
+    if (detail::is_valid_multipart_boundary(boundary))
+        boundary_ = std::move(boundary);
 }

--- a/src/core/HttpMsg.cc
+++ b/src/core/HttpMsg.cc
@@ -6,6 +6,10 @@
 
 #include <unistd.h>
 #include <algorithm>
+#include <cstdlib>
+#include <cstdint>
+#include <memory>
+#include <vector>
 
 #include "HttpMsg.h"
 #include "UriUtil.h"
@@ -16,6 +20,7 @@
 #include "HttpServerTask.h"
 #include "CodeUtil.h"
 #include "HttpHeaderUtil.h"
+#include "MultipartUtil.h"
 #include "PushWriteUtil.h"
 
 using namespace protocol;
@@ -198,6 +203,89 @@ bool extract_multipart_boundary(const std::string &content_type,
     }
 
     return found;
+}
+
+struct MultipartResponseContext
+{
+    HttpResp *resp;
+    std::string boundary;
+    std::string content;
+    bool failed;
+};
+
+struct MultipartFileContext
+{
+    MultipartResponseContext *response;
+    std::string path;
+    std::string field_name;
+    std::string filename;
+    std::string content_type;
+    void *buffer;
+    size_t expected_size;
+    bool final_task;
+};
+
+void append_multipart_part_prefix(MultipartResponseContext *context)
+{
+    if (!context->content.empty())
+        context->content.append("\r\n");
+
+    context->content.append("--");
+    context->content.append(context->boundary);
+    context->content.append("\r\n");
+}
+
+void append_multipart_closing_delimiter(MultipartResponseContext *context)
+{
+    if (!context->content.empty())
+        context->content.append("\r\n");
+
+    context->content.append("--");
+    context->content.append(context->boundary);
+    context->content.append("--\r\n");
+}
+
+void append_multipart_param(MultipartResponseContext *context,
+                            const std::string& field_name,
+                            const std::string& value)
+{
+    std::string encoded_name;
+    if (!detail::encode_multipart_quoted_value(field_name, &encoded_name))
+        return;
+
+    append_multipart_part_prefix(context);
+    context->content.append("Content-Disposition: form-data; name=\"");
+    context->content.append(encoded_name);
+    context->content.append("\"\r\n\r\n");
+    context->content.append(value);
+}
+
+void append_multipart_file(MultipartFileContext *file)
+{
+    MultipartResponseContext *context = file->response;
+    append_multipart_part_prefix(context);
+    context->content.append("Content-Disposition: form-data; name=\"");
+    context->content.append(file->field_name);
+    context->content.append("\"; filename=\"");
+    context->content.append(file->filename);
+    context->content.append("\"\r\nContent-Type: ");
+    context->content.append(file->content_type);
+    context->content.append("\r\n\r\n");
+    context->content.append(static_cast<const char *>(file->buffer),
+                            file->expected_size);
+}
+
+void finish_multipart_response(MultipartResponseContext *context)
+{
+    if (context->failed)
+    {
+        context->resp->Error(StatusFileReadError);
+        return;
+    }
+
+    append_multipart_closing_delimiter(context);
+    context->resp->append_output_body_nocopy(context->content.c_str(),
+                                             context->content.size());
 }
 
 } // namespace
@@ -734,111 +822,123 @@ void HttpResp::String(MultiPartEncoder &&multi_part_encoder)
 
 void HttpResp::String(MultiPartEncoder *encoder)
 {
-    const std::string &boudary = encoder->boundary();
-    this->headers["Content-Type"] = "multipart/form-data; boundary=" + boudary;
-
+    std::unique_ptr<MultiPartEncoder> encoder_owner(encoder);
     HttpServerTask *server_task = task_of(this);
     SeriesWork *series = series_of(server_task);
+    MultipartResponseContext *response = new MultipartResponseContext{
+        this, encoder_owner->boundary(), std::string(), false
+    };
+    this->headers["Content-Type"] =
+        "multipart/form-data; boundary=\"" + response->boundary + "\"";
 
-    std::string *content = new std::string;
-    series->set_context(content);
-    series->set_callback([encoder](const SeriesWork *series)
-    {
-        delete encoder;
-        delete static_cast<std::string *>(series->get_context());
-    });
+    for (const auto& param : encoder_owner->params())
+        append_multipart_param(response, param.first, param.second);
 
-    const MultiPartEncoder::ParamList &param_list = encoder->params();
-    int param_idx = 0;
-    for(const auto &param : param_list)
+    std::vector<MultipartFileContext *> files;
+    bool allocation_failed = false;
+    for (const auto& file : encoder_owner->files())
     {
-        if (param_idx != 0)
-        {
-            content->append("\r\n");
-        }
-        param_idx++;
-        content->append("--");
-        content->append(boudary);
-        content->append("\r\nContent-Disposition: form-data; name=\"");
-        content->append(param.first);
-        content->append("\"\r\n\r\n");
-        content->append(param.second);
-    }
-    const MultiPartEncoder::FileList &file_list = encoder->files();
-    size_t file_cnt = file_list.size();
-    if (file_cnt == 0)
-    {
-        content->append("\r\n--");
-        content->append(boudary);
-        content->append("--\r\n");
-        this->append_output_body_nocopy(content->c_str(), content->size());
-    }
-    size_t file_idx = 0;
-    for(const auto &file : file_list)
-    {
-        if(!PathUtil::is_file(file.second))
+        if (!PathUtil::is_file(file.second))
         {
             fprintf(stderr, "[Error] Not a File : %s\n", file.second.c_str());
             continue;
         }
-        size_t file_size;
-        int ret = FileUtil::size(file.second, &file_size);
-        if (ret != StatusOK)
+
+        size_t file_size = 0;
+        if (FileUtil::size(file.second, &file_size) != StatusOK)
         {
             fprintf(stderr, "[Error] Invalid File : %s\n", file.second.c_str());
             continue;
         }
-        void *buf = malloc(file_size);
-        server_task->add_callback([buf](const HttpTask *)
-                                {
-                                    free(buf);
-                                });
-        WFFileIOTask *pread_task = WFTaskFactory::create_pread_task(file.second,
-                buf, file_size, 0,
-                [&file, &boudary, param_idx, file_idx](WFFileIOTask *pread_task)
-                {
-                    FileIOArgs *args = pread_task->get_args();
-                    long ret = pread_task->get_retval();
 
-                    SeriesWork *series = series_of(pread_task);
-                    std::string *content = static_cast<std::string *>(series->get_context());
-                    if (pread_task->get_state() != WFT_STATE_SUCCESS || ret < 0)
-                    {
-                        fprintf(stderr, "Read %s Error\n", file.second.c_str());
-                    } else
-                    {
-                        std::string file_suffix = PathUtil::suffix(file.second);
-                        std::string file_type = ContentType::to_str_by_suffix(file_suffix);
-                        if (param_idx != 0 || file_idx != 0)
-                        {
-                            content->append("\r\n");
-                        }
-                        content->append("--");
-                        content->append(boudary);
-                        content->append("\r\nContent-Disposition: form-data; name=\"");
-                        content->append(file.first);
-                        content->append("\"; filename=\"");
-                        content->append(PathUtil::base(file.second));
-                        content->append("\"\r\nContent-Type: ");
-                        content->append(file_type);
-                        content->append("\r\n\r\n");
-                        content->append(static_cast<char *>(args->buf), ret);
-                    }
-                    // last one, send the content
-                    if(pread_task->user_data) {
-                        content->append("\r\n--");
-                        content->append(boudary);
-                        content->append("--\r\n");
-                        HttpResp *resp = static_cast<HttpResp *>(pread_task->user_data);
-                        resp->append_output_body_nocopy(content->c_str(), content->size());
-                    }
-                });
-        if(file_idx == file_cnt - 1)
+        std::string field_name;
+        std::string filename;
+        if (!detail::encode_multipart_quoted_value(file.first, &field_name) ||
+            !detail::encode_multipart_quoted_value(
+                PathUtil::base(file.second), &filename))
         {
-            pread_task->user_data = this;
+            fprintf(stderr, "[Error] Invalid Multipart Metadata : %s\n",
+                    file.second.c_str());
+            continue;
         }
+
+        void *buffer = std::malloc(file_size == 0 ? 1 : file_size);
+        if (buffer == nullptr)
+        {
+            allocation_failed = true;
+            break;
+        }
+
+        MultipartFileContext *file_context = new MultipartFileContext{
+            response,
+            file.second,
+            std::move(field_name),
+            std::move(filename),
+            ContentType::to_str_by_suffix(PathUtil::suffix(file.second)),
+            buffer,
+            file_size,
+            false
+        };
+        files.push_back(file_context);
+    }
+
+    if (allocation_failed)
+    {
+        for (MultipartFileContext *file : files)
+        {
+            std::free(file->buffer);
+            delete file;
+        }
+        delete response;
+        this->Error(StatusFileReadError);
+        return;
+    }
+
+    server_task->add_callback([response](const HttpTask *) {
+        delete response;
+    });
+
+    if (files.empty())
+    {
+        finish_multipart_response(response);
+        return;
+    }
+
+    files.back()->final_task = true;
+    for (MultipartFileContext *file : files)
+    {
+        server_task->add_callback([file](const HttpTask *) {
+            std::free(file->buffer);
+            delete file;
+        });
+
+        WFFileIOTask *pread_task = WFTaskFactory::create_pread_task(
+            file->path, file->buffer, file->expected_size, 0,
+            [](WFFileIOTask *task)
+            {
+                MultipartFileContext *file =
+                    static_cast<MultipartFileContext *>(task->user_data);
+                const long retval = task->get_retval();
+                const bool exact_read =
+                    task->get_state() == WFT_STATE_SUCCESS && retval >= 0 &&
+                    static_cast<std::uintmax_t>(retval) ==
+                        static_cast<std::uintmax_t>(file->expected_size);
+
+                if (!exact_read)
+                {
+                    fprintf(stderr, "Read %s Error\n", file->path.c_str());
+                    file->response->failed = true;
+                }
+                else
+                {
+                    append_multipart_file(file);
+                }
+
+                if (file->final_task)
+                    finish_multipart_response(file->response);
+            });
+        pread_task->user_data = file;
         series->push_back(pread_task);
-        file_idx++;
     }
 }
 

--- a/src/core/MultipartUtil.h
+++ b/src/core/MultipartUtil.h
@@ -1,0 +1,82 @@
+#ifndef WFREST_MULTIPARTUTIL_H_
+#define WFREST_MULTIPARTUTIL_H_
+
+#include <string>
+
+namespace wfrest
+{
+namespace detail
+{
+
+inline bool is_multipart_boundary_char(unsigned char ch)
+{
+    if ((ch >= '0' && ch <= '9') ||
+        (ch >= 'A' && ch <= 'Z') ||
+        (ch >= 'a' && ch <= 'z'))
+    {
+        return true;
+    }
+
+    switch (ch)
+    {
+        case ' ':
+        case '\'':
+        case '(':
+        case ')':
+        case '+':
+        case '_':
+        case ',':
+        case '-':
+        case '.':
+        case '/':
+        case ':':
+        case '=':
+        case '?':
+            return true;
+        default:
+            return false;
+    }
+}
+
+inline bool is_valid_multipart_boundary(const std::string& boundary)
+{
+    if (boundary.empty() || boundary.size() > 70 || boundary.back() == ' ')
+        return false;
+
+    for (unsigned char ch : boundary)
+    {
+        if (!is_multipart_boundary_char(ch))
+            return false;
+    }
+
+    return true;
+}
+
+inline bool encode_multipart_quoted_value(const std::string& value,
+                                          std::string *encoded)
+{
+    encoded->clear();
+    if (value.empty())
+        return false;
+
+    for (unsigned char ch : value)
+    {
+        if (ch != '\t' && (ch < 0x20 || ch == 0x7f))
+            return false;
+    }
+
+    encoded->reserve(value.size());
+    for (char ch : value)
+    {
+        if (ch == '"' || ch == '\\')
+            encoded->push_back('\\');
+        encoded->push_back(ch);
+    }
+
+    return true;
+}
+
+} // namespace detail
+} // namespace wfrest
+
+#endif // WFREST_MULTIPARTUTIL_H_

--- a/test/HttpContent_unittest.cc
+++ b/test/HttpContent_unittest.cc
@@ -110,6 +110,27 @@ TEST(MultiPartForm, rejects_invalid_boundaries)
     EXPECT_TRUE(parser.parse_multipart(StringPiece(valid_body)).empty());
 }
 
+TEST(MultiPartEncoder, preserves_valid_boundary_on_invalid_assignment)
+{
+    MultiPartEncoder encoder;
+    EXPECT_EQ(encoder.boundary(), MultiPartForm::k_default_boundary);
+
+    encoder.set_boundary("a:b?c");
+    EXPECT_EQ(encoder.boundary(), "a:b?c");
+
+    encoder.set_boundary("");
+    EXPECT_EQ(encoder.boundary(), "a:b?c");
+
+    encoder.set_boundary(std::string("bad;boundary"));
+    EXPECT_EQ(encoder.boundary(), "a:b?c");
+
+    encoder.set_boundary("trailing ");
+    EXPECT_EQ(encoder.boundary(), "a:b?c");
+
+    encoder.set_boundary(std::string(71, 'a'));
+    EXPECT_EQ(encoder.boundary(), "a:b?c");
+}
+
 TEST(MultiPartForm, parses_structural_content_disposition)
 {
     MultiPartForm parser;

--- a/test/HttpServer/send_form_test.cc
+++ b/test/HttpServer/send_form_test.cc
@@ -1,10 +1,14 @@
 #include "workflow/WFFacilities.h"
+#include "workflow/HttpUtil.h"
+#include <unistd.h>
 #include <gtest/gtest.h>
 #include "wfrest/HttpServer.h"
 #include "wfrest/ErrorCode.h"
+#include "wfrest/Json.h"
 #include "wfrest/PathUtil.h"
 #include "wfrest/FileUtil.h"
 #include "wfrest/HttpContent.h"
+#include "wfrest/StringPiece.h"
 #include "../ClientUtil.h"
 #include "../FileTestUtil.h"
 
@@ -53,7 +57,7 @@ TEST_F(MultiPartEncoderTest, multi_part_form_params)
     HttpServer svr;
     WFFacilities::WaitGroup wait_group(1);
 
-    svr.GET("/form", [](const HttpReq *req, HttpResp *resp)
+    svr.GET("/form", [](const HttpReq *, HttpResp *resp)
     {
         MultiPartEncoder encoder;
         encoder.add_param("Filename1", "1.jpg");
@@ -105,7 +109,7 @@ TEST_F(MultiPartEncoderTest, multi_part_form_files)
     HttpServer svr;
     WFFacilities::WaitGroup wait_group(1);
 
-    svr.GET("/form", [](const HttpReq *req, HttpResp *resp)
+    svr.GET("/form", [](const HttpReq *, HttpResp *resp)
     {
         MultiPartEncoder encoder;
         encoder.add_file("test_1.txt", "./www/test_1.txt");
@@ -162,7 +166,7 @@ TEST_F(MultiPartEncoderTest, multi_part_form_param_file)
     HttpServer svr;
     WFFacilities::WaitGroup wait_group(1);
 
-    svr.GET("/form", [](const HttpReq *req, HttpResp *resp)
+    svr.GET("/form", [](const HttpReq *, HttpResp *resp)
     {
         MultiPartEncoder encoder;
         encoder.add_param("Filename", "1.jpg");
@@ -221,4 +225,184 @@ TEST_F(MultiPartEncoderTest, multi_part_form_param_file)
     client_task->start();
     wait_group.wait();
     svr.stop();
+}
+
+TEST_F(MultiPartEncoderTest, validates_boundary_and_quoted_metadata)
+{
+    HttpServer server;
+    WFFacilities::WaitGroup wait_group(2);
+
+    server.GET("/empty", [](const HttpReq *, HttpResp *resp)
+    {
+        MultiPartEncoder encoder;
+        encoder.add_file("missing", "./www/missing-empty");
+        resp->String(std::move(encoder));
+    });
+    server.GET("/metadata", [](const HttpReq *, HttpResp *resp)
+    {
+        MultiPartEncoder encoder;
+        encoder.set_boundary("a:b?c");
+        encoder.add_param("quo\"te\\field", "value");
+        encoder.add_param("bad\r\nInjected", "ignored");
+        resp->String(std::move(encoder));
+    });
+
+    ASSERT_EQ(server.start("127.0.0.1", 8888), 0);
+
+    WFHttpTask *empty_task = ClientUtil::create_http_task("empty");
+    empty_task->set_callback([&wait_group](WFHttpTask *task)
+    {
+        HttpHeaderMap headers(task->get_resp());
+        EXPECT_EQ(headers.get("Content-Type"),
+                  "multipart/form-data; boundary=\"" +
+                      MultiPartForm::k_default_boundary + "\"");
+
+        const void *body = nullptr;
+        size_t body_len = 0;
+        EXPECT_TRUE(task->get_resp()->get_parsed_body(&body, &body_len));
+        EXPECT_EQ(std::string(static_cast<const char *>(body), body_len),
+                  "--" + MultiPartForm::k_default_boundary + "--\r\n");
+        wait_group.done();
+    });
+
+    WFHttpTask *metadata_task = ClientUtil::create_http_task("metadata");
+    metadata_task->set_callback([&wait_group](WFHttpTask *task)
+    {
+        HttpHeaderMap headers(task->get_resp());
+        EXPECT_EQ(headers.get("Content-Type"),
+                  "multipart/form-data; boundary=\"a:b?c\"");
+
+        const void *body = nullptr;
+        size_t body_len = 0;
+        EXPECT_TRUE(task->get_resp()->get_parsed_body(&body, &body_len));
+        const std::string content(static_cast<const char *>(body), body_len);
+        EXPECT_EQ(content.find("bad\r\nInjected"), std::string::npos);
+
+        MultiPartForm parser;
+        parser.set_boundary("a:b?c");
+        const Form form = parser.parse_multipart(StringPiece(content));
+        EXPECT_EQ(form.size(), 1U);
+        if (form.count("quo\"te\\field") != 0)
+        {
+            EXPECT_EQ(form.at("quo\"te\\field").second, "value");
+        }
+        wait_group.done();
+    });
+
+    SeriesWork *series = Workflow::create_series_work(empty_task, nullptr);
+    series->push_back(metadata_task);
+    series->start();
+    wait_group.wait();
+    server.stop();
+}
+
+TEST_F(MultiPartEncoderTest, owns_file_tasks_and_preserves_series_state)
+{
+    const std::string special_path = dir_path_ + "/a\"b\\c.txt";
+    const std::string empty_path = dir_path_ + "/empty.txt";
+    const std::string invalid_metadata_path =
+        dir_path_ + "/bad\r\nfilename.txt";
+    ASSERT_TRUE(FileTestUtil::write_file(special_path, "special-body"));
+    ASSERT_TRUE(FileTestUtil::write_file(empty_path, ""));
+    ASSERT_TRUE(FileTestUtil::write_file(invalid_metadata_path, "ignored"));
+
+    HttpServer server;
+    WFFacilities::WaitGroup wait_group(2);
+    int series_context = 42;
+
+    server.GET("/files", [&](const HttpReq *, HttpResp *resp,
+                              SeriesWork *series)
+    {
+        series->set_context(&series_context);
+        series->set_callback([&wait_group, &series_context](
+            const SeriesWork *completed)
+        {
+            EXPECT_EQ(completed->get_context(), &series_context);
+            wait_group.done();
+        });
+
+        MultiPartEncoder encoder;
+        encoder.add_file("missing-before", dir_path_ + "/missing-before");
+        encoder.add_file("up\"load\\field", special_path);
+        encoder.add_file("empty", empty_path);
+        encoder.add_file("bad\r\nfield", special_path);
+        encoder.add_file("bad-filename", invalid_metadata_path);
+        encoder.add_file("missing-after", dir_path_ + "/missing-after");
+        resp->String(std::move(encoder));
+    });
+
+    ASSERT_EQ(server.start("127.0.0.1", 8888), 0);
+
+    WFHttpTask *client_task = ClientUtil::create_http_task("files");
+    client_task->set_callback([&wait_group, &special_path](WFHttpTask *task)
+    {
+        EXPECT_STREQ(task->get_resp()->get_status_code(), "200");
+        const void *body = nullptr;
+        size_t body_len = 0;
+        EXPECT_TRUE(task->get_resp()->get_parsed_body(&body, &body_len));
+        const std::string content(static_cast<const char *>(body), body_len);
+
+        MultiPartForm parser;
+        parser.set_boundary(MultiPartForm::k_default_boundary);
+        const Form form = parser.parse_multipart(StringPiece(content));
+        EXPECT_EQ(form.size(), 2U);
+        if (form.count("up\"load\\field") != 0)
+        {
+            EXPECT_EQ(form.at("up\"load\\field").first,
+                      PathUtil::base(special_path));
+            EXPECT_EQ(form.at("up\"load\\field").second, "special-body");
+        }
+        if (form.count("empty") != 0)
+        {
+            EXPECT_EQ(form.at("empty").first, "empty.txt");
+            EXPECT_TRUE(form.at("empty").second.empty());
+        }
+        wait_group.done();
+    });
+
+    client_task->start();
+    wait_group.wait();
+    server.stop();
+}
+
+TEST_F(MultiPartEncoderTest, rejects_short_file_reads)
+{
+    HttpServer server;
+    WFFacilities::WaitGroup wait_group(1);
+    const std::string path = file_list_.back();
+
+    server.GET("/short-read", [&path](const HttpReq *, HttpResp *resp)
+    {
+        MultiPartEncoder encoder;
+        encoder.add_file("upload", path);
+        resp->String(std::move(encoder));
+
+        EXPECT_EQ(truncate(path.c_str(), 1), 0);
+    });
+
+    ASSERT_EQ(server.start("127.0.0.1", 8888), 0);
+
+    WFHttpTask *client_task = ClientUtil::create_http_task("short-read");
+    client_task->set_callback([&wait_group](WFHttpTask *task)
+    {
+        EXPECT_STREQ(task->get_resp()->get_status_code(), "503");
+        HttpHeaderMap headers(task->get_resp());
+        EXPECT_EQ(headers.get("Content-Type"), "application/json");
+
+        const void *body = nullptr;
+        size_t body_len = 0;
+        EXPECT_TRUE(task->get_resp()->get_parsed_body(&body, &body_len));
+        const Json error = Json::parse(
+            std::string(static_cast<const char *>(body), body_len));
+        EXPECT_TRUE(error.is_valid());
+        if (error.is_valid())
+        {
+            EXPECT_EQ(error["errmsg"].get<std::string>(), "File Read Error");
+        }
+        wait_group.done();
+    });
+
+    client_task->start();
+    wait_group.wait();
+    server.stop();
 }


### PR DESCRIPTION
## Why

`HttpResp::String(MultiPartEncoder*)` borrowed a range-for variable and boundary by reference from asynchronous callbacks, selected its final callback from unfiltered file count, accepted short reads, and replaced application-owned SeriesWork context/callback state. Invalid files could therefore suppress the response, while multiple files could access expired stack state. Empty bodies and raw quoted metadata were also structurally unsafe.

## Plan implemented

- share one 1–70 byte multipart boundary validator across parser and encoder
- preserve the encoder default/last valid boundary and quote it in Content-Type
- validate and escape quoted `name`/`filename` metadata
- preflight regular files, sizes, metadata, and buffers before scheduling tasks
- own response/file state independently of the input encoder and loop variables
- preserve application SeriesWork context and callback
- require exact asynchronous reads and let one explicit final task attach the body or emit File Read Error
- render parameter-only, all-invalid-file, empty-file, and truly empty bodies with exact delimiters

## Validation

- strict production compile: C++11 with `-Wall -Wextra -Wpedantic -Werror` (workflow headers treated as system dependencies)
- strict modified-test compile: `-Wall -Wextra -Wpedantic -Werror`
- focused unit/integration: 2/2 CTest executables passed
- full regression suite: 36/36 CTest passed
- ASan/UBSan/LSan: complete HttpContent and 6-case send_form executables passed with wfrest/tests instrumented
- sanitizer note: workflow itself has a pre-route `strndup` interceptor over-read; the focused run used normal workflow binaries and `intercept_strndup=0` so that known dependency finding did not mask wfrest lifecycle checks
- `git diff --check`

Spec: #338
Tracks #337.