### PR TITLE
fix(json): parse exact streaming input (#340)

### DIFF
--- a/src/base/Json.cc
+++ b/src/base/Json.cc
@@ -22,7 +22,7 @@ Json::Json(const char* str)
 {
 }
 
-Json::Json(std::nullptr_t null)
+Json::Json(std::nullptr_t)
     : node_(json_value_create(JSON_VALUE_NULL)), parent_(nullptr),
       allocated_(true)
 {
@@ -47,10 +47,14 @@ Json::Json(const std::vector<std::string>& val)
 }
 
 // for parse
-Json::Json(const std::string& str, bool parse_flag) : parent_(nullptr)
+Json::Json(const std::string& str, bool)
+    : node_(nullptr), parent_(nullptr), allocated_(false)
 {
+    if (str.find('\0') != std::string::npos)
+        return;
+
     node_ = json_value_parse(str.c_str());
-    allocated_ = node_ == nullptr ? false : true;
+    allocated_ = node_ != nullptr;
 }
 
 Json::~Json()
@@ -146,26 +150,31 @@ Json Json::parse(const std::ifstream& stream)
 Json Json::parse(FILE* fp)
 {
     if (fp == nullptr)
+        return Json(std::string(), true);
+
+    clearerr(fp);
+    if (fseek(fp, 0, SEEK_SET) != 0)
+        clearerr(fp);
+
+    std::string input;
+    char buffer[8192];
+    while (true)
     {
-        return Json();
+        const size_t size = fread(buffer, 1, sizeof(buffer), fp);
+        if (size != 0)
+            input.append(buffer, size);
+
+        if (size == sizeof(buffer))
+            continue;
+        if (ferror(fp))
+            return Json(std::string(), true);
+        if (feof(fp))
+            break;
+        if (size == 0)
+            return Json(std::string(), true);
     }
-    fseek(fp, 0, SEEK_END);
-    long length = ftell(fp);
-    fseek(fp, 0, SEEK_SET);
-    char* buffer = (char*)malloc(length + 1);
-    buffer[length] = '\0';
-    long ret = fread(buffer, 1, length, fp);
-    Json js;
-    if (ret != length)
-    {
-        js = Json();
-    }
-    else
-    {
-        js = Json(buffer, true);
-    }
-    free(buffer);
-    return js;
+
+    return Json(input, true);
 }
 
 std::string Json::dump() const
@@ -435,7 +444,7 @@ void Json::placeholder_push_back(const std::string& key, bool val)
     }
 }
 
-void Json::placeholder_push_back(const std::string& key, std::nullptr_t val)
+void Json::placeholder_push_back(const std::string& key, std::nullptr_t)
 {
     json_object_t* obj = json_value_object(parent_);
     destroy_node(&node_);
@@ -493,7 +502,7 @@ void Json::normal_push_back(const std::string& key, bool val)
     json_value_destroy(remove_val);
 }
 
-void Json::normal_push_back(const std::string& key, std::nullptr_t val)
+void Json::normal_push_back(const std::string& key, std::nullptr_t)
 {
     json_object_t* obj = json_value_object(parent_);
     const json_value_t* find = json_object_find(key.c_str(), obj);
@@ -663,7 +672,7 @@ void Json::update_arr(bool val)
     json_value_destroy(remove_val);
 }
 
-void Json::update_arr(std::nullptr_t val)
+void Json::update_arr(std::nullptr_t)
 {
     json_array_t* arr = json_value_array(parent_);
     json_array_insert_before(node_, arr, JSON_VALUE_NULL);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,7 @@ set(UNIT_TEST_LIST
 	TimeStamp_unittest
 	StrUtil_unittest
 	StringPiece_unittest
+	Json_unittest
 	Compress_unittest
 	Router_unittest
 	base64_unittest

--- a/test/Json_unittest.cc
+++ b/test/Json_unittest.cc
@@ -1,0 +1,137 @@
+#include <cerrno>
+#include <cstdio>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+#include "wfrest/Json.h"
+
+using namespace wfrest;
+
+namespace
+{
+
+using FilePtr = std::unique_ptr<FILE, int (*)(FILE *)>;
+
+bool write_all(int fd, const char *data, size_t size)
+{
+    size_t offset = 0;
+    while (offset < size)
+    {
+        const ssize_t written = write(fd, data + offset, size - offset);
+        if (written > 0)
+        {
+            offset += static_cast<size_t>(written);
+            continue;
+        }
+        if (written < 0 && errno == EINTR)
+            continue;
+        return false;
+    }
+    return true;
+}
+
+std::string raw_nul_document()
+{
+    std::string input = "{\"prefix\":true}";
+    input.push_back('\0');
+    input.append("not-json");
+    return input;
+}
+
+} // namespace
+
+TEST(JsonParse, rejects_embedded_raw_nul)
+{
+    EXPECT_FALSE(Json::parse(raw_nul_document()).is_valid());
+    EXPECT_TRUE(Json::parse("{\"escaped\":\"\\u0000\"}").is_valid());
+
+    FilePtr stream(tmpfile(), fclose);
+    ASSERT_NE(stream, nullptr);
+    const std::string input = raw_nul_document();
+    ASSERT_EQ(fwrite(input.data(), 1, input.size(), stream.get()),
+              input.size());
+    EXPECT_FALSE(Json::parse(stream.get()).is_valid());
+}
+
+TEST(JsonParse, rejects_null_empty_and_read_error_streams)
+{
+    EXPECT_FALSE(Json::parse(static_cast<FILE *>(nullptr)).is_valid());
+
+    FilePtr empty(tmpfile(), fclose);
+    ASSERT_NE(empty, nullptr);
+    EXPECT_FALSE(Json::parse(empty.get()).is_valid());
+
+    FilePtr directory(fopen(".", "r"), fclose);
+    if (directory != nullptr)
+    {
+        EXPECT_FALSE(Json::parse(directory.get()).is_valid());
+    }
+}
+
+TEST(JsonParse, rewinds_and_consumes_multichunk_seekable_file)
+{
+    const std::string value(20000, 'x');
+    const std::string input = "{\"value\":\"" + value + "\"}";
+
+    FilePtr stream(tmpfile(), fclose);
+    ASSERT_NE(stream, nullptr);
+    ASSERT_EQ(fwrite(input.data(), 1, input.size(), stream.get()),
+              input.size());
+    ASSERT_EQ(fseek(stream.get(), 100, SEEK_SET), 0);
+
+    const Json parsed = Json::parse(stream.get());
+    ASSERT_TRUE(parsed.is_valid());
+    EXPECT_EQ(parsed["value"].get<std::string>(), value);
+    EXPECT_NE(feof(stream.get()), 0);
+    EXPECT_EQ(ftell(stream.get()), static_cast<long>(input.size()));
+}
+
+TEST(JsonParse, reads_nonseekable_stream_from_current_position)
+{
+    int descriptors[2];
+    ASSERT_EQ(pipe(descriptors), 0);
+
+    const std::string input = "{\"pipe\":true}";
+    ASSERT_TRUE(write_all(descriptors[1], input.data(), input.size()));
+    ASSERT_EQ(close(descriptors[1]), 0);
+
+    FilePtr stream(fdopen(descriptors[0], "r"), fclose);
+    ASSERT_NE(stream, nullptr);
+    const Json parsed = Json::parse(stream.get());
+    ASSERT_TRUE(parsed.is_valid());
+    EXPECT_TRUE(parsed["pipe"].get<bool>());
+    EXPECT_NE(feof(stream.get()), 0);
+}
+
+TEST(JsonParse, rejects_empty_nonseekable_stream)
+{
+    int descriptors[2];
+    ASSERT_EQ(pipe(descriptors), 0);
+    ASSERT_EQ(close(descriptors[1]), 0);
+
+    FilePtr stream(fdopen(descriptors[0], "r"), fclose);
+    ASSERT_NE(stream, nullptr);
+    EXPECT_FALSE(Json::parse(stream.get()).is_valid());
+}
+
+TEST(JsonParse, rejects_embedded_nul_from_ifstream)
+{
+    const std::string path = "./wfrest-json-embedded-nul.tmp";
+    const std::string input = raw_nul_document();
+    {
+        std::ofstream output(path, std::ios::binary | std::ios::trunc);
+        ASSERT_TRUE(output.is_open());
+        output.write(input.data(), static_cast<std::streamsize>(input.size()));
+        ASSERT_TRUE(output.good());
+    }
+
+    std::ifstream stream(path, std::ios::binary);
+    ASSERT_TRUE(stream.is_open());
+    EXPECT_FALSE(Json::parse(stream).is_valid());
+    stream.close();
+    EXPECT_EQ(unlink(path.c_str()), 0);
+}


### PR DESCRIPTION
## Why

`Json::parse(FILE*)` converted failed `ftell()` results into allocation sizes and wrote a terminator at index `-1` for pipes, while null/read-error streams returned valid JSON null. Every parse overload also passed `std::string::c_str()` to the bundled parser without rejecting raw embedded NUL, allowing trailing bytes to be ignored.

## Plan implemented

- reject raw NUL in the private parsing constructor shared by all parse overloads
- return the invalid parsed representation for null, empty, and read-error streams
- preserve rewind-to-byte-zero for seekable FILE inputs
- clear failed seek state and consume non-seekable streams from their current position
- replace `ftell`/manual allocation with checked 8 KiB chunk reads
- register `Json_unittest` with CTest
- cover string/FILE/ifstream NUL, null/empty/error streams, multi-chunk rewind, and pipe input

## Validation

- pre-fix ASan probe: pipe reproduced a one-byte heap-buffer-underflow
- post-fix same probe: embedded NUL rejected; pipe parsed successfully; no sanitizer report
- strict production C++11: `-Wall -Wextra -Wpedantic -Werror`
- strict modified test compile: `-Wall -Wextra -Wpedantic -Werror`
- focused tests: 6/6 cases in `Json_unittest`
- ASan/UBSan/LSan: `Json_unittest` passed
- full regression suite: 37/37 CTest passed
- `git diff --check`

Spec: #341
Tracks #340.