### PR TITLE
fix(stringpiece): normalize null inputs and saturate trimming

### DIFF
--- a/src/base/StringPiece.h
+++ b/src/base/StringPiece.h
@@ -14,6 +14,9 @@ namespace wfrest
 class StringPiece
 {
 private:
+    static const char *empty_data()
+    { return ""; }
+
     const char *ptr_;
     size_t length_;
 
@@ -22,23 +25,27 @@ public:
     // in a "const char*" or a "std::string" wherever a "StringPiece" is
     // expected.
     StringPiece()
-            : ptr_(nullptr), length_(0)
+            : ptr_(empty_data()), length_(0)
     {}
 
     StringPiece(const char *str)
-            : ptr_(str), length_(strlen(ptr_))
+            : ptr_(str == nullptr ? empty_data() : str),
+              length_(str == nullptr ? 0 : strlen(str))
     {}
 
     StringPiece(const std::string &str)
-            : ptr_(str.data()), length_(str.size())
+            : ptr_(str.c_str()), length_(str.size())
     {}
 
     StringPiece(const char *offset, size_t len)
-            : ptr_(offset), length_(len)
+            : ptr_(offset == nullptr ? empty_data() : offset),
+              length_(offset == nullptr ? 0 : len)
     {}
 
     StringPiece(const void *str, size_t len)
-            : ptr_(static_cast<const char *>(str)), length_(len)
+            : ptr_(str == nullptr ? empty_data() :
+                   static_cast<const char *>(str)),
+              length_(str == nullptr ? 0 : len)
     {}
 
     // data() may return a pointer to a buffer with embedded NULs, and the
@@ -64,30 +71,53 @@ public:
 
     void clear()
     {
-        ptr_ = nullptr;
+        ptr_ = empty_data();
         length_ = 0;
     }
 
     void set(const char *buffer, int len)
     {
-        ptr_ = buffer;
-        length_ = len;
+        if (len < 0)
+        {
+            clear();
+            return;
+        }
+
+        set(buffer, static_cast<size_t>(len));
     }
 
     void set(const char *str)
     {
+        if (str == nullptr)
+        {
+            clear();
+            return;
+        }
+
         ptr_ = str;
         length_ = strlen(str);
     }
 
     void set(const char *buffer, size_t len)
     {
+        if (buffer == nullptr)
+        {
+            clear();
+            return;
+        }
+
         ptr_ = buffer;
         length_ = len;
     }
 
     void set(const void *buffer, size_t len)
     {
+        if (buffer == nullptr)
+        {
+            clear();
+            return;
+        }
+
         ptr_ = static_cast<const char *>(buffer);
         length_ = len;
     }
@@ -97,20 +127,21 @@ public:
 
     void remove_prefix(size_t n)
     {
-        ptr_ += n;
-        length_ -= n;
+        const size_t removed = n < length_ ? n : length_;
+        ptr_ += removed;
+        length_ -= removed;
     }
 
     void remove_suffix(size_t n)
     {
-        length_ -= n;
+        const size_t removed = n < length_ ? n : length_;
+        length_ -= removed;
     }
 
     void shrink(size_t prefix, size_t suffix)
     {
-        ptr_ += prefix;
-        length_ -= prefix;
-        length_ -= suffix;
+        remove_prefix(prefix);
+        remove_suffix(suffix);
     }
 
     bool operator==(const StringPiece &x) const

--- a/test/StringPiece_unittest.cc
+++ b/test/StringPiece_unittest.cc
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <map>
 #include <unordered_map>
 #include "wfrest/StringPiece.h"
 
@@ -76,4 +77,105 @@ TEST(StringPiece, shrink)
     StringPiece str("1234567890");
     str.shrink(0, 2);
     EXPECT_EQ("12345678", str.as_string());
+}
+
+TEST(StringPiece, normalizes_null_and_default_views)
+{
+    StringPiece empty;
+    EXPECT_NE(empty.data(), nullptr);
+    EXPECT_EQ(empty.begin(), empty.end());
+    EXPECT_TRUE(empty.empty());
+    EXPECT_TRUE(empty.as_string().empty());
+
+    std::string copied = "not-empty";
+    empty.CopyToString(&copied);
+    EXPECT_TRUE(copied.empty());
+
+    const StringPiece literal_empty("");
+    EXPECT_EQ(empty, literal_empty);
+    EXPECT_EQ(empty.compare(literal_empty), 0);
+    EXPECT_TRUE(empty.starts_with(literal_empty));
+    EXPECT_EQ(StringPieceHash()(empty), StringPieceHash()(literal_empty));
+
+    size_t iterations = 0;
+    for (char value : empty)
+    {
+        static_cast<void>(value);
+        ++iterations;
+    }
+    EXPECT_EQ(iterations, 0U);
+
+    const StringPiece null_string(static_cast<const char *>(nullptr));
+    const StringPiece null_bytes(static_cast<const char *>(nullptr), 10);
+    const StringPiece null_void(static_cast<const void *>(nullptr), 10);
+    EXPECT_EQ(null_string, empty);
+    EXPECT_EQ(null_bytes, empty);
+    EXPECT_EQ(null_void, empty);
+    EXPECT_NE(null_string.data(), nullptr);
+    EXPECT_NE(null_bytes.data(), nullptr);
+    EXPECT_NE(null_void.data(), nullptr);
+
+    empty.clear();
+    EXPECT_NE(empty.data(), nullptr);
+    EXPECT_TRUE(empty.empty());
+}
+
+TEST(StringPiece, normalizes_setter_lengths)
+{
+    const char buffer[] = "abc";
+    StringPiece piece("value");
+
+    piece.set(static_cast<const char *>(nullptr));
+    EXPECT_NE(piece.data(), nullptr);
+    EXPECT_TRUE(piece.empty());
+
+    piece.set(static_cast<const char *>(nullptr), static_cast<size_t>(3));
+    EXPECT_NE(piece.data(), nullptr);
+    EXPECT_TRUE(piece.empty());
+
+    piece.set(static_cast<const void *>(nullptr), 3U);
+    EXPECT_NE(piece.data(), nullptr);
+    EXPECT_TRUE(piece.empty());
+
+    piece.set(buffer, -1);
+    EXPECT_NE(piece.data(), nullptr);
+    EXPECT_TRUE(piece.empty());
+
+    piece.set(buffer, 0);
+    EXPECT_EQ(piece.data(), buffer);
+    EXPECT_TRUE(piece.empty());
+
+    piece.set(buffer, 2);
+    EXPECT_EQ(piece.data(), buffer);
+    EXPECT_EQ(piece.as_string(), "ab");
+}
+
+TEST(StringPiece, saturates_removal_at_current_size)
+{
+    const char input[] = "abc";
+
+    StringPiece prefix(input);
+    prefix.remove_prefix(99);
+    EXPECT_TRUE(prefix.empty());
+    EXPECT_EQ(prefix.data(), input + 3);
+    prefix.remove_prefix(1);
+    EXPECT_EQ(prefix.data(), input + 3);
+    EXPECT_TRUE(prefix.as_string().empty());
+
+    StringPiece suffix(input);
+    suffix.remove_suffix(99);
+    EXPECT_TRUE(suffix.empty());
+    EXPECT_EQ(suffix.data(), input);
+    suffix.remove_suffix(1);
+    EXPECT_EQ(suffix.data(), input);
+
+    StringPiece both(input);
+    both.shrink(2, 99);
+    EXPECT_TRUE(both.empty());
+    EXPECT_EQ(both.data(), input + 2);
+
+    StringPiece oversized_prefix(input);
+    oversized_prefix.shrink(99, 99);
+    EXPECT_TRUE(oversized_prefix.empty());
+    EXPECT_EQ(oversized_prefix.data(), input + 3);
 }


### PR DESCRIPTION
## Why

`StringPiece` accepted null C-string inputs and unchecked signed or oversized lengths. That left several empty-view operations outside their valid domains:

- `StringPiece(nullptr)` called `strlen(nullptr)` and triggered undefined behavior.
- `set(buffer, -1)` converted the negative length to a huge `size_t`.
- `remove_prefix()`, `remove_suffix()`, and `shrink()` underflowed when asked to remove more bytes than remained.
- default and cleared views retained a null data pointer, making iterator-style empty ranges unnecessarily fragile.

This implements the contract defined by spec PR #344 and tracks issue #343.

## Plan implemented

1. Represent default, cleared, and null-derived empty views with a stable non-null sentinel.
2. Normalize null pointer-plus-length inputs and negative signed lengths to empty views.
3. Preserve valid non-null zero-length pointers and use `std::string::c_str()` for string-backed views.
4. Saturate prefix and suffix removal at the current size; make `shrink()` apply those operations in order.
5. Add regression coverage for constructors, setters, comparisons, hashing, iteration, pointer positions, repeated removals, and oversized trims.

## Compatibility

- Existing valid non-null inputs retain their pointer and length behavior.
- `operator[]` remains unchecked and still requires an in-range non-negative index.
- Over-removal now produces the largest valid empty subview instead of wrapping the length.

## Validation

- Strict standalone consumer: C++11, `-Wall -Wextra -Wpedantic -Werror`.
- Strict unit source compile: C++14, `-Wall -Wextra -Wpedantic -Werror`, exceptions disabled.
- ASan + UBSan minimal reproducer: default, null constructor, negative length, and oversized prefix cases all pass.
- ASan + UBSan: `StringPiece_unittest` and `StrUtil_unittest` pass (2/2).
- Focused ordinary tests: `StringPiece_unittest` and `StrUtil_unittest` pass (2/2).
- Full ordinary suite: 37/37 tests pass.

Issue: #343
Spec: #344
