### PR TITLE
fix(http-date): emit reentrant UTC protocol timestamps

### DIFF
--- a/src/base/Timestamp.cc
+++ b/src/base/Timestamp.cc
@@ -1,6 +1,61 @@
 #include "Timestamp.h"
 
+#include <ctime>
+#include <limits>
+#include <locale>
+
 using namespace wfrest;
+
+namespace
+{
+
+enum class Timezone
+{
+    LOCAL,
+    UTC
+};
+
+bool calendar_time(std::time_t value, Timezone timezone, std::tm *result)
+{
+#if defined(_WIN32)
+    if (timezone == Timezone::UTC)
+        return gmtime_s(result, &value) == 0;
+    return localtime_s(result, &value) == 0;
+#else
+    if (timezone == Timezone::UTC)
+        return gmtime_r(&value, result) != nullptr;
+    return localtime_r(&value, result) != nullptr;
+#endif
+}
+
+std::string format_timestamp(uint64_t microseconds,
+                             const char *format,
+                             Timezone timezone)
+{
+    if (format == nullptr)
+        return {};
+
+    const uint64_t seconds =
+        microseconds / Timestamp::k_micro_sec_per_sec;
+    if (seconds >
+        static_cast<uint64_t>(std::numeric_limits<std::time_t>::max()))
+    {
+        return {};
+    }
+
+    const std::time_t value = static_cast<std::time_t>(seconds);
+    std::tm calendar{};
+    if (!calendar_time(value, timezone, &calendar))
+        return {};
+
+    std::stringstream stream;
+    if (timezone == Timezone::UTC)
+        stream.imbue(std::locale::classic());
+    stream << std::put_time(&calendar, format);
+    return stream.fail() ? std::string() : stream.str();
+}
+
+} // namespace
 
 static_assert(sizeof(Timestamp) == sizeof(uint64_t),
               "Timestamp should be same size as uint64_t");
@@ -44,10 +99,17 @@ std::string Timestamp::to_format_str() const
 
 std::string Timestamp::to_format_str(const char *fmt) const
 {
-    std::time_t time = micro_sec_since_epoch_ / k_micro_sec_per_sec;  // ms --> s
-    std::stringstream ss;
-    ss << std::put_time(std::localtime(&time), fmt);
-    return ss.str();
+    return format_timestamp(micro_sec_since_epoch_, fmt, Timezone::LOCAL);
+}
+
+std::string Timestamp::to_utc_format_str() const
+{
+    return to_utc_format_str("%Y-%m-%d %X");
+}
+
+std::string Timestamp::to_utc_format_str(const char *fmt) const
+{
+    return format_timestamp(micro_sec_since_epoch_, fmt, Timezone::UTC);
 }
 
 uint64_t Timestamp::micro_sec_since_epoch() const
@@ -60,4 +122,3 @@ Timestamp Timestamp::now()
     uint64_t timestamp = duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
     return Timestamp(timestamp);
 }
-

--- a/src/base/Timestamp.h
+++ b/src/base/Timestamp.h
@@ -32,6 +32,10 @@ public:
 
     std::string to_format_str(const char *fmt) const;
 
+    std::string to_utc_format_str() const;
+
+    std::string to_utc_format_str(const char *fmt) const;
+
     uint64_t micro_sec_since_epoch() const;
 
     bool valid() const

--- a/src/core/HttpCookie.cc
+++ b/src/core/HttpCookie.cc
@@ -154,7 +154,8 @@ std::string HttpCookie::dump() const
     else if (expires_.valid())
     {
         ret.append("Expires=")
-                .append(expires_.to_format_str("%a, %d %b %Y %H:%M:%S GMT"))
+                .append(expires_.to_utc_format_str(
+                    "%a, %d %b %Y %H:%M:%S GMT"))
                 .append("; ");
     }
     if (!domain_.empty())

--- a/src/core/HttpServerTask.cc
+++ b/src/core/HttpServerTask.cc
@@ -68,7 +68,8 @@ CommMessageOut *HttpServerTask::message_out()
     }
     if(headers.find("Date") == headers.end())
     {
-        headers["Date"] = Timestamp::now().to_format_str("%a, %d %b %Y %H:%M:%S GMT");
+        headers["Date"] = Timestamp::now().to_utc_format_str(
+            "%a, %d %b %Y %H:%M:%S GMT");
     }
     struct HttpMessageHeader header;
 

--- a/test/HttpCookie_unittest.cc
+++ b/test/HttpCookie_unittest.cc
@@ -1,8 +1,48 @@
-#include <vector>
 #include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <ctime>
+#include <string>
+#include <vector>
+
 #include "wfrest/HttpCookie.h"
 
 using namespace wfrest;
+
+namespace
+{
+
+class ScopedTimezone
+{
+public:
+    explicit ScopedTimezone(const char *timezone)
+    {
+        const char *current = std::getenv("TZ");
+        if (current != nullptr)
+        {
+            had_value_ = true;
+            value_ = current;
+        }
+
+        (void)setenv("TZ", timezone, 1);
+        tzset();
+    }
+
+    ~ScopedTimezone()
+    {
+        if (had_value_)
+            (void)setenv("TZ", value_.c_str(), 1);
+        else
+            (void)unsetenv("TZ");
+        tzset();
+    }
+
+private:
+    bool had_value_ = false;
+    std::string value_;
+};
+
+} // namespace
 
 TEST(HttpCookie, dump)
 {
@@ -24,6 +64,16 @@ TEST(HttpCookie, same_site)
             .set_same_site(SameSite::NONE);
 
     EXPECT_EQ(cookie.dump(), "user=wfrest; Max-Age=1000; Domain=/; SameSite=None; Secure");
+}
+
+TEST(HttpCookie, expires_uses_utc_when_process_timezone_does_not)
+{
+    ScopedTimezone timezone("EST5");
+    HttpCookie cookie("session", "value");
+    cookie.set_expires(Timestamp(1000000));
+
+    EXPECT_EQ(cookie.dump(),
+              "session=value; Expires=Thu, 01 Jan 1970 00:00:01 GMT");
 }
 
 TEST(HttpCookie, split)

--- a/test/HttpServer/header_test.cc
+++ b/test/HttpServer/header_test.cc
@@ -1,10 +1,13 @@
 #include <gtest/gtest.h>
 
+#include <cstdlib>
+#include <ctime>
 #include <string>
 #include <vector>
 
 #include "wfrest/HttpServer.h"
 #include "wfrest/Json.h"
+#include "wfrest/Timestamp.h"
 #include "workflow/WFFacilities.h"
 #include "../ClientUtil.h"
 
@@ -13,6 +16,54 @@ using namespace wfrest;
 
 namespace
 {
+
+class ScopedTimezone
+{
+public:
+    explicit ScopedTimezone(const char *timezone)
+    {
+        const char *current = std::getenv("TZ");
+        if (current != nullptr)
+        {
+            had_value_ = true;
+            value_ = current;
+        }
+
+        (void)setenv("TZ", timezone, 1);
+        tzset();
+    }
+
+    ~ScopedTimezone()
+    {
+        if (had_value_)
+            (void)setenv("TZ", value_.c_str(), 1);
+        else
+            (void)unsetenv("TZ");
+        tzset();
+    }
+
+private:
+    bool had_value_ = false;
+    std::string value_;
+};
+
+bool is_recent_utc_http_date(const std::string& value)
+{
+    const uint64_t now = Timestamp::now().micro_sec_since_epoch() /
+                         Timestamp::k_micro_sec_per_sec;
+    const uint64_t first = now > 5 ? now - 5 : 0;
+    for (uint64_t second = first; second <= now + 5; ++second)
+    {
+        const Timestamp candidate(
+            second * Timestamp::k_micro_sec_per_sec);
+        if (candidate.to_utc_format_str(
+                "%a, %d %b %Y %H:%M:%S GMT") == value)
+        {
+            return true;
+        }
+    }
+    return false;
+}
 
 std::string response_body(WFHttpTask *task)
 {
@@ -27,6 +78,7 @@ std::string response_body(WFHttpTask *task)
 
 TEST(HttpServer, validates_response_headers_and_framing)
 {
+    ScopedTimezone timezone("EST5");
     HttpServer server;
     WFFacilities::WaitGroup wait_group(5);
 
@@ -73,6 +125,7 @@ TEST(HttpServer, validates_response_headers_and_framing)
         EXPECT_EQ(task->get_state(), WFT_STATE_SUCCESS);
         HttpHeaderMap headers(task->get_resp());
         EXPECT_EQ(headers.get("X-Safe"), "yes");
+        EXPECT_TRUE(is_recent_utc_http_date(headers.get("Date")));
         EXPECT_TRUE(headers.get("X-Injected").empty());
         EXPECT_TRUE(headers.get("X-Direct-Injected").empty());
         EXPECT_TRUE(headers.get("Bad:Direct").empty());

--- a/test/TimeStamp_unittest.cc
+++ b/test/TimeStamp_unittest.cc
@@ -1,14 +1,157 @@
 #include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <ctime>
+#include <locale>
+#include <string>
+#include <thread>
+#include <vector>
+
 #include "wfrest/Timestamp.h"
-#include <iostream>
 
 using namespace wfrest;
 
-int main()
+namespace
 {
-    Timestamp ts(1639279032782231L);
-    std::cout << ts.to_format_str() << std::endl;
-    std::cout << ts.to_format_str("%a, %d %b %Y %H:%M:%S GMT") << std::endl;
 
-    return 0;
+class ScopedTimezone
+{
+public:
+    explicit ScopedTimezone(const char *timezone)
+    {
+        const char *current = std::getenv("TZ");
+        if (current != nullptr)
+        {
+            had_value_ = true;
+            value_ = current;
+        }
+
+        (void)setenv("TZ", timezone, 1);
+        tzset();
+    }
+
+    ~ScopedTimezone()
+    {
+        if (had_value_)
+            (void)setenv("TZ", value_.c_str(), 1);
+        else
+            (void)unsetenv("TZ");
+        tzset();
+    }
+
+private:
+    bool had_value_ = false;
+    std::string value_;
+};
+
+class MarkerTimePut : public std::time_put<char>
+{
+protected:
+    iter_type do_put(iter_type output,
+                     std::ios_base&,
+                     char_type,
+                     const std::tm *,
+                     char,
+                     char) const override
+    {
+        *output++ = 'X';
+        return output;
+    }
+};
+
+class ScopedMarkerLocale
+{
+public:
+    ScopedMarkerLocale()
+        : previous_(std::locale())
+    {
+        std::locale::global(std::locale(previous_, new MarkerTimePut));
+    }
+
+    ~ScopedMarkerLocale()
+    {
+        std::locale::global(previous_);
+    }
+
+private:
+    std::locale previous_;
+};
+
+} // namespace
+
+TEST(Timestamp, separates_local_and_utc_formatting)
+{
+    ScopedTimezone timezone("EST5");
+    const Timestamp instant(1000000);
+
+    EXPECT_EQ(instant.to_format_str("%Y-%m-%d %H:%M:%S"),
+              "1969-12-31 19:00:01");
+    EXPECT_EQ(instant.to_utc_format_str("%Y-%m-%d %H:%M:%S"),
+              "1970-01-01 00:00:01");
+    EXPECT_EQ(instant.to_utc_format_str("%a, %d %b %Y %H:%M:%S GMT"),
+              "Thu, 01 Jan 1970 00:00:01 GMT");
+    EXPECT_FALSE(instant.to_format_str().empty());
+    EXPECT_FALSE(instant.to_utc_format_str().empty());
+}
+
+TEST(Timestamp, rejects_null_formats)
+{
+    const Timestamp instant(1000000);
+    EXPECT_TRUE(instant.to_format_str(nullptr).empty());
+    EXPECT_TRUE(instant.to_utc_format_str(nullptr).empty());
+    EXPECT_TRUE(instant.to_format_str("").empty());
+    EXPECT_TRUE(instant.to_utc_format_str("").empty());
+}
+
+TEST(Timestamp, utc_formatting_uses_the_classic_locale)
+{
+    ScopedTimezone timezone("UTC0");
+    ScopedMarkerLocale locale;
+    const Timestamp instant(1000000);
+
+    EXPECT_EQ(instant.to_format_str("%a"), "X");
+    EXPECT_EQ(instant.to_utc_format_str("%a"), "Thu");
+}
+
+TEST(Timestamp, formats_concurrently_from_owned_calendar_storage)
+{
+    ScopedTimezone timezone("EST5");
+    constexpr size_t thread_count = 12;
+    constexpr size_t iterations = 1000;
+    const char *format = "%Y-%m-%d %H:%M:%S";
+
+    std::vector<Timestamp> timestamps;
+    std::vector<std::string> expected_local;
+    std::vector<std::string> expected_utc;
+    for (size_t i = 0; i < thread_count; ++i)
+    {
+        timestamps.emplace_back(
+            (1 + i * 24 * 60 * 60) * Timestamp::k_micro_sec_per_sec);
+        expected_local.emplace_back(timestamps.back().to_format_str(format));
+        expected_utc.emplace_back(
+            timestamps.back().to_utc_format_str(format));
+    }
+
+    std::atomic<bool> valid(true);
+    std::vector<std::thread> threads;
+    for (size_t i = 0; i < thread_count; ++i)
+    {
+        threads.emplace_back([&, i]
+        {
+            for (size_t j = 0; j < iterations; ++j)
+            {
+                if (timestamps[i].to_format_str(format) != expected_local[i] ||
+                    timestamps[i].to_utc_format_str(format) != expected_utc[i])
+                {
+                    valid.store(false, std::memory_order_relaxed);
+                    return;
+                }
+            }
+        });
+    }
+
+    for (std::thread& thread : threads)
+        thread.join();
+    EXPECT_TRUE(valid.load(std::memory_order_relaxed));
 }


### PR DESCRIPTION
## Why

Automatic response `Date` and cookie `Expires` values claimed to be GMT but were built with `std::localtime()`. Non-UTC deployments therefore emitted the wrong instant, while concurrent calls depended on shared static calendar storage. The formatter also inherited process locale for protocol weekday/month names.

Under `TZ=EST5`, one second after the Unix epoch previously serialized as `Wed, 31 Dec 1969 19:00:01 GMT`; it now serializes as `Thu, 01 Jan 1970 00:00:01 GMT`.

This implements spec PR #347 and tracks issue #346.

## Plan implemented

1. Centralize null checking, range checking, calendar conversion, and formatting in `Timestamp.cc`.
2. Use caller-owned `std::tm` storage through reentrant POSIX/Windows calendar APIs.
3. Preserve local `to_format_str()` semantics and add `to_utc_format_str()` overloads.
4. Force the new UTC path to `std::locale::classic()` for stable HTTP names.
5. Migrate response `Date` and cookie `Expires` to UTC; keep server tracking local.
6. Replace the print-only timestamp smoke test with timezone, null, locale, and concurrent assertions; cover cookies and a live server response.

## Compatibility

- Existing local-time formatting remains local and retains the stream's locale behavior.
- The UTC API is additive.
- Only fields that already contain the literal `GMT` change, and they now represent the correct instant.
- Tracking logs remain process-local.

## Validation

- Fixed `TZ=EST5` reproducer now emits correct UTC timestamp and cookie expiry.
- Strict production compile: C++11, `-Wall -Wextra -Wpedantic -Werror`.
- Strict test compile: C++14, `-Wall -Wextra -Wpedantic -Werror`, exceptions disabled.
- Focused ordinary tests: timestamp, cookie, and live header tests pass (3/3).
- ASan + UBSan focused tests: 3/3 pass.
- Full ordinary suite: 37/37 tests pass.

Issue: #346
Spec: #347
