### PR TITLE
fix(compress): stream safely across aliases and bounds

### DIFF
--- a/src/base/Compress.cc
+++ b/src/base/Compress.cc
@@ -1,11 +1,52 @@
-
-#include <cassert>
 #include "Compress.h"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <utility>
+
 #include "ErrorCode.h"
 
 namespace wfrest
 {
-const char* compress_method_to_str(const Compress& compress_method)
+
+namespace
+{
+
+constexpr size_t kOutputBufferSize = 16 * 1024;
+
+int fail(std::string *dest, int status)
+{
+    if (dest != nullptr)
+        dest->clear();
+    return status;
+}
+
+void assign_input(z_stream *stream,
+                  const char *data,
+                  size_t len,
+                  size_t *offset)
+{
+    if (stream->avail_in != 0 || *offset == len)
+        return;
+
+    const size_t amount = std::min(
+        len - *offset,
+        static_cast<size_t>(std::numeric_limits<uInt>::max()));
+    stream->next_in = reinterpret_cast<Bytef *>(
+        const_cast<char *>(data + *offset));
+    stream->avail_in = static_cast<uInt>(amount);
+    *offset += amount;
+}
+
+size_t produced_size(const z_stream& stream)
+{
+    return kOutputBufferSize - stream.avail_out;
+}
+
+} // namespace
+
+const char *compress_method_to_str(const Compress& compress_method)
 {
     switch (compress_method)
     {
@@ -15,153 +56,123 @@ const char* compress_method_to_str(const Compress& compress_method)
             return "unsupport compression";
     }
 }
-}  // namespace wfrest
-
-using namespace wfrest;
 
 int Compressor::gzip(const std::string * const src, std::string *dest)
 {
-    const char *data = src->c_str();
-    const size_t len = src->size();
-    return gzip(data, len, dest);
+    if (dest == nullptr)
+        return StatusCompressError;
+    if (src == nullptr)
+        return fail(dest, StatusCompressError);
+    return gzip(src->c_str(), src->size(), dest);
 }
 
 int Compressor::gzip(const char *data, const size_t len, std::string *dest)
 {
-    dest->clear();
-    z_stream strm = {nullptr,
-                     0,
-                     0,
-                     nullptr,
-                     0,
-                     0,
-                     nullptr,
-                     nullptr,
-                     nullptr,
-                     nullptr,
-                     nullptr,
-                     0,
-                     0,
-                     0};
-    if (data && len > 0)
+    if (dest == nullptr)
+        return StatusCompressError;
+    if (data == nullptr && len != 0)
+        return fail(dest, StatusCompressError);
+
+    z_stream stream{};
+    if (deflateInit2(&stream,
+                     Z_DEFAULT_COMPRESSION,
+                     Z_DEFLATED,
+                     MAX_WBITS + 16,
+                     8,
+                     Z_DEFAULT_STRATEGY) != Z_OK)
     {
-        if (deflateInit2(&strm,
-                         Z_DEFAULT_COMPRESSION,  
-                         Z_DEFLATED,
-                         MAX_WBITS + 16,
-                         8,
-                         Z_DEFAULT_STRATEGY) != Z_OK)
-        {
-            // fprintf(stderr, "deflateInit2 error!\n");
-            return StatusCompressError;
-        }
-        std::string outstr;
-        outstr.resize(compressBound(static_cast<uLong>(len)));
-        strm.next_in = (Bytef *)data;
-        strm.avail_in = static_cast<uInt>(len);
-        int ret;
+        return fail(dest, StatusCompressError);
+    }
+
+    std::array<char, kOutputBufferSize> buffer{};
+    std::string output;
+    size_t offset = 0;
+    int status = Z_OK;
+
+    while (status != Z_STREAM_END)
+    {
+        assign_input(&stream, data, len, &offset);
+        const int flush = offset == len && stream.avail_in == 0
+                          ? Z_FINISH
+                          : Z_NO_FLUSH;
+
         do
         {
-            if (strm.total_out >= outstr.size())
+            stream.next_out = reinterpret_cast<Bytef *>(buffer.data());
+            stream.avail_out = static_cast<uInt>(buffer.size());
+            status = deflate(&stream, flush);
+            if (status != Z_OK && status != Z_STREAM_END)
             {
-                outstr.resize(strm.total_out * 2);
+                (void)deflateEnd(&stream);
+                return fail(dest, StatusCompressError);
             }
-            assert(outstr.size() >= strm.total_out);
-            strm.avail_out = static_cast<uInt>(outstr.size() - strm.total_out);
-            strm.next_out = (Bytef *)outstr.data() + strm.total_out;
-            ret = deflate(&strm, Z_FINISH); /* no bad return value */
-            if (ret == Z_STREAM_ERROR)
-            {
-                (void)deflateEnd(&strm);
-                return StatusCompressError;
-            }
-        } while (strm.avail_out == 0);
-        assert(strm.avail_in == 0);
-        assert(ret == Z_STREAM_END); /* stream will be complete */
-        outstr.resize(strm.total_out);
-        /* clean up and return */
-        (void)deflateEnd(&strm);
-        *dest = std::move(outstr);
-        return StatusOK;
+
+            output.append(buffer.data(), produced_size(stream));
+        } while (stream.avail_out == 0);
     }
-    return StatusCompressError;
+
+    if (deflateEnd(&stream) != Z_OK)
+        return fail(dest, StatusCompressError);
+
+    *dest = std::move(output);
+    return StatusOK;
 }
+
 int Compressor::ungzip(const std::string * const src, std::string *dest)
 {
-    const char *data = src->c_str();
-    const size_t len = src->size();
-    return ungzip(data, len, dest);
+    if (dest == nullptr)
+        return StatusUncompressError;
+    if (src == nullptr)
+        return fail(dest, StatusUncompressError);
+    return ungzip(src->c_str(), src->size(), dest);
 }
 
 int Compressor::ungzip(const char *data, const size_t len, std::string *dest)
 {
-    dest->clear();
+    if (dest == nullptr)
+        return StatusUncompressError;
     if (len == 0)
+    {
+        dest->clear();
         return StatusOK;
-
-    auto full_length = len;
-
-    auto decompressed = std::string(full_length * 2, 0);
-    bool done = false;
-
-    z_stream strm = {nullptr,
-                     0,
-                     0,
-                     nullptr,
-                     0,
-                     0,
-                     nullptr,
-                     nullptr,
-                     nullptr,
-                     nullptr,
-                     nullptr,
-                     0,
-                     0,
-                     0};
-    strm.next_in = (Bytef *)data;
-    strm.avail_in = static_cast<uInt>(len);
-    strm.total_out = 0;
-    strm.zalloc = Z_NULL;
-    strm.zfree = Z_NULL;
-    if (inflateInit2(&strm, (15 + 32)) != Z_OK)
-    {
-        // fprintf(stderr, "inflateInit2 error!\n");
-        return StatusUncompressError;
     }
-    while (!done)
+    if (data == nullptr)
+        return fail(dest, StatusUncompressError);
+
+    z_stream stream{};
+    if (inflateInit2(&stream, 15 + 32) != Z_OK)
+        return fail(dest, StatusUncompressError);
+
+    std::array<char, kOutputBufferSize> buffer{};
+    std::string output;
+    size_t offset = 0;
+    int status = Z_OK;
+
+    while (status != Z_STREAM_END)
     {
-        // Make sure we have enough room and reset the lengths.
-        if (strm.total_out >= decompressed.length())
-        {
-            decompressed.resize(decompressed.length() * 2);
-        }
-        strm.next_out = (Bytef *)decompressed.data() + strm.total_out;
-        strm.avail_out =
-                static_cast<uInt>(decompressed.length() - strm.total_out);
-        // Inflate another chunk.
-        int status = inflate(&strm, Z_SYNC_FLUSH);
+        assign_input(&stream, data, len, &offset);
+        stream.next_out = reinterpret_cast<Bytef *>(buffer.data());
+        stream.avail_out = static_cast<uInt>(buffer.size());
+
+        status = inflate(&stream, Z_NO_FLUSH);
+        const size_t produced = produced_size(stream);
+        output.append(buffer.data(), produced);
+
         if (status == Z_STREAM_END)
-        {
-            done = true;
-        }
-        else if (status != Z_OK)
-        {
             break;
+        if (status != Z_OK ||
+            (produced == 0 && stream.avail_in == 0 && offset == len))
+        {
+            (void)inflateEnd(&stream);
+            return fail(dest, StatusUncompressError);
         }
     }
-    if (inflateEnd(&strm) != Z_OK)
-        return StatusUncompressError;
-    // Set real length.
-    int status = StatusOK;
-    if (done)
-    {
-        decompressed.resize(strm.total_out);
-        *dest = std::move(decompressed);
-    }
-    else
-    {
-        status = StatusUncompressError;
-    }
-    return status;
+
+    if (inflateEnd(&stream) != Z_OK)
+        return fail(dest, StatusUncompressError);
+
+    *dest = std::move(output);
+    return StatusOK;
 }
 
+} // namespace wfrest

--- a/test/Compress_unittest.cc
+++ b/test/Compress_unittest.cc
@@ -1,36 +1,168 @@
-#include "wfrest/ErrorCode.h"
 #include <gtest/gtest.h>
+
+#include <string>
+
 #include "wfrest/Compress.h"
+#include "wfrest/ErrorCode.h"
 
 using namespace wfrest;
 
-TEST(gzip, shortText)
+namespace
 {
-    std::string str = "WFREST compress : Just for test....";
-    std::string compress_str;
-    int ret = Compressor::gzip(&str, &compress_str);
-    EXPECT_EQ(ret, StatusOK);
-    std::string decompress_str;
-    ret = Compressor::ungzip(&compress_str, &decompress_str);
-    EXPECT_EQ(ret, StatusOK);
-    EXPECT_EQ(str, decompress_str);
+
+std::string gzip_value(const std::string& source)
+{
+    std::string encoded;
+    EXPECT_EQ(Compressor::gzip(&source, &encoded), StatusOK);
+    return encoded;
 }
 
-TEST(gzip, longText)
+void expect_round_trip(const std::string& source)
 {
-    std::string str;
-    for (size_t i = 0; i < 100000; i++)
-    {
-        str.append(std::to_string(i));
-    }
-    auto *compress_str = new std::string;
-    int ret = Compressor::gzip(&str, compress_str);
-    EXPECT_EQ(ret, StatusOK);
+    const std::string encoded = gzip_value(source);
+    std::string decoded;
+    EXPECT_EQ(Compressor::ungzip(&encoded, &decoded), StatusOK);
+    EXPECT_EQ(decoded, source);
+}
 
-    auto *decompress_str = new std::string;
-    ret = Compressor::ungzip(compress_str, decompress_str);
-    EXPECT_EQ(ret, StatusOK);
-    EXPECT_EQ(str, *decompress_str);
-    delete compress_str;
-    delete decompress_str;
+} // namespace
+
+TEST(Compressor, round_trips_short_and_long_text)
+{
+    expect_round_trip("WFREST compress : Just for test....");
+
+    std::string long_text;
+    for (size_t i = 0; i < 100000; ++i)
+        long_text.append(std::to_string(i));
+    expect_round_trip(long_text);
+}
+
+TEST(Compressor, round_trips_binary_and_empty_payloads)
+{
+    const char binary_bytes[] = {
+        '\0', '\1', static_cast<char>(0xFF), 'a', '\0', 'z'};
+    expect_round_trip(
+        std::string(binary_bytes, sizeof(binary_bytes)));
+
+    std::string encoded = "stale";
+    EXPECT_EQ(Compressor::gzip(nullptr, 0, &encoded), StatusOK);
+    EXPECT_FALSE(encoded.empty());
+
+    std::string decoded = "stale";
+    EXPECT_EQ(Compressor::ungzip(&encoded, &decoded), StatusOK);
+    EXPECT_TRUE(decoded.empty());
+
+    std::string empty;
+    EXPECT_EQ(Compressor::gzip(&empty, &empty), StatusOK);
+    EXPECT_FALSE(empty.empty());
+    EXPECT_EQ(Compressor::ungzip(&empty, &empty), StatusOK);
+    EXPECT_TRUE(empty.empty());
+}
+
+TEST(Compressor, supports_string_source_destination_aliases)
+{
+    const std::string original =
+        "abcdefghijklmnopqrstuvwxyz0123456789";
+    std::string value = original;
+
+    EXPECT_EQ(Compressor::gzip(&value, &value), StatusOK);
+    EXPECT_NE(value, original);
+    EXPECT_EQ(Compressor::ungzip(&value, &value), StatusOK);
+    EXPECT_EQ(value, original);
+}
+
+TEST(Compressor, supports_raw_ranges_backed_by_destination)
+{
+    const std::string original =
+        "abcdefghijklmnopqrstuvwxyz0123456789";
+    std::string value = original;
+
+    EXPECT_EQ(Compressor::gzip(value.data(), value.size(), &value), StatusOK);
+    EXPECT_EQ(Compressor::ungzip(value.data(), value.size(), &value), StatusOK);
+    EXPECT_EQ(value, original);
+
+    value = "prefix-payload-suffix";
+    EXPECT_EQ(Compressor::gzip(value.data() + 7, 7, &value), StatusOK);
+    std::string decoded;
+    EXPECT_EQ(Compressor::ungzip(&value, &decoded), StatusOK);
+    EXPECT_EQ(decoded, "payload");
+}
+
+TEST(Compressor, preserves_zlib_and_trailing_byte_compatibility)
+{
+    const std::string source = "zlib-wrapped payload";
+    uLongf encoded_size = compressBound(static_cast<uLong>(source.size()));
+    std::string encoded(static_cast<size_t>(encoded_size), '\0');
+    ASSERT_EQ(compress2(
+                  reinterpret_cast<Bytef *>(&encoded[0]),
+                  &encoded_size,
+                  reinterpret_cast<const Bytef *>(source.data()),
+                  static_cast<uLong>(source.size()),
+                  Z_BEST_SPEED),
+              Z_OK);
+    encoded.resize(static_cast<size_t>(encoded_size));
+    encoded.append("trailing bytes");
+
+    std::string decoded;
+    EXPECT_EQ(Compressor::ungzip(&encoded, &decoded), StatusOK);
+    EXPECT_EQ(decoded, source);
+}
+
+TEST(Compressor, validates_null_boundaries_and_clears_failures)
+{
+    const std::string source = "value";
+    std::string destination = "stale";
+
+    EXPECT_EQ(Compressor::gzip(
+                  static_cast<const std::string *>(nullptr), &destination),
+              StatusCompressError);
+    EXPECT_TRUE(destination.empty());
+
+    destination = "stale";
+    EXPECT_EQ(Compressor::ungzip(
+                  static_cast<const std::string *>(nullptr), &destination),
+              StatusUncompressError);
+    EXPECT_TRUE(destination.empty());
+
+    destination = "stale";
+    EXPECT_EQ(Compressor::gzip(nullptr, 1, &destination),
+              StatusCompressError);
+    EXPECT_TRUE(destination.empty());
+
+    destination = "stale";
+    EXPECT_EQ(Compressor::ungzip(nullptr, 1, &destination),
+              StatusUncompressError);
+    EXPECT_TRUE(destination.empty());
+
+    EXPECT_EQ(Compressor::gzip(&source, nullptr), StatusCompressError);
+    EXPECT_EQ(Compressor::gzip(source.data(), source.size(), nullptr),
+              StatusCompressError);
+    EXPECT_EQ(Compressor::ungzip(&source, nullptr), StatusUncompressError);
+    EXPECT_EQ(Compressor::ungzip(source.data(), source.size(), nullptr),
+              StatusUncompressError);
+
+    destination = "stale";
+    EXPECT_EQ(Compressor::ungzip(nullptr, 0, &destination), StatusOK);
+    EXPECT_TRUE(destination.empty());
+}
+
+TEST(Compressor, rejects_malformed_and_truncated_streams)
+{
+    std::string destination = "stale";
+    const std::string malformed = "not a gzip stream";
+    EXPECT_EQ(Compressor::ungzip(&malformed, &destination),
+              StatusUncompressError);
+    EXPECT_TRUE(destination.empty());
+
+    std::string truncated = gzip_value("payload");
+    ASSERT_FALSE(truncated.empty());
+    truncated.pop_back();
+    destination = "stale";
+    EXPECT_EQ(Compressor::ungzip(&truncated, &destination),
+              StatusUncompressError);
+    EXPECT_TRUE(destination.empty());
+
+    EXPECT_EQ(Compressor::ungzip(&truncated, &truncated),
+              StatusUncompressError);
+    EXPECT_TRUE(truncated.empty());
 }


### PR DESCRIPTION
## Why

The previous compression helpers cleared `dest` before zlib consumed input. In-place string/raw calls therefore silently corrupted gzip output or failed and lost compressed input. Empty gzip was rejected, null object pointers triggered UB, full `size_t` lengths were narrowed to `uInt`, and ungzip preallocated `len * 2` bytes without knowing actual output.

The pre-fix probe reported successful-but-wrong alias round trips; the same probe now reports exact matches for string gzip, string ungzip, and raw-buffer aliasing, and empty gzip produces a valid 20-byte member.

This implements spec PR #350 and tracks issue #349.

## Plan implemented

1. Validate destination, string source, and raw pointer/length boundaries with existing status codes.
2. Stage every result independently and mutate a valid destination only at final success or failure.
3. Feed input through `uInt`-bounded chunks tracked by an external `size_t` cursor.
4. Collect actual zlib output through a fixed 16 KiB block; remove `compressBound` output sizing and `len * 2` decompression guesses.
5. Complete empty gzip through `Z_FINISH`; retain successful empty ungzip compatibility.
6. Detect malformed, truncated, no-progress, and unexpected zlib states and clear a valid destination.
7. Expand tests for aliases, raw subranges, binary/empty data, nulls, stale outputs, zlib wrappers, trailing bytes, and incomplete streams.

## Compatibility

- Existing valid non-aliased gzip/zlib streams retain their status and bytes.
- zlib auto-detection and trailing-byte behavior remain unchanged.
- Errors still clear a valid destination.
- Empty gzip and supported aliasing become additive successful cases.
- Public signatures and error codes are unchanged.

## Validation

- Fixed ASan/UBSan probe: all alias matches succeed; empty member round trips; null boundaries return 2/5 without findings.
- Strict production compile: C++11, `-Wall -Wextra -Wpedantic -Werror`.
- Strict test compile: C++14, `-Wall -Wextra -Wpedantic -Werror`, exceptions disabled.
- Focused ordinary tests: `Compress_unittest` and HTTP `server_send_test` pass (2/2).
- ASan + UBSan focused tests: 2/2 pass.
- Full ordinary suite: 37/37 tests pass.

Issue: #349
Spec: #350
