### PR TITLE
fix(base64): validate complete input with checked APIs

### DIFF
--- a/src/base/base64.cc
+++ b/src/base/base64.cc
@@ -1,104 +1,206 @@
 #include "base64.h"
-using namespace wfrest;
 
-namespace 
+#include <utility>
+
+namespace wfrest
 {
 
-bool is_base64(unsigned char c) {
-    return (isalnum(c) || (c == '+') || (c == '/'));
+namespace
+{
+
+bool fail(std::string *output)
+{
+    if (output != nullptr)
+        output->clear();
+    return false;
 }
 
-} // namespace 
+int base64_value(unsigned char byte)
+{
+    if (byte >= 'A' && byte <= 'Z')
+        return byte - 'A';
+    if (byte >= 'a' && byte <= 'z')
+        return byte - 'a' + 26;
+    if (byte >= '0' && byte <= '9')
+        return byte - '0' + 52;
+    if (byte == '+')
+        return 62;
+    if (byte == '/')
+        return 63;
+    return -1;
+}
 
+} // namespace
 
 const std::string Base64::base64_chars =
-                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                    "abcdefghijklmnopqrstuvwxyz"
-                    "0123456789+/";
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz"
+    "0123456789+/";
 
-
-
-std::string Base64::encode(const unsigned char *bytes_to_encode, unsigned int len)
+std::string Base64::encode(const unsigned char *bytes_to_encode,
+                           unsigned int len)
 {
-    std::string ret;
-    int i = 0;
-    int j = 0;
-    unsigned char char_array_3[3];
-    unsigned char char_array_4[4];
+    std::string output;
+    (void)encode(bytes_to_encode, static_cast<size_t>(len), &output);
+    return output;
+}
 
-    while (len--) {
-        char_array_3[i++] = *(bytes_to_encode++);
-        if (i == 3) {
-            char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
-            char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
-            char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
-            char_array_4[3] = char_array_3[2] & 0x3f;
+bool Base64::encode(const unsigned char *data,
+                    size_t len,
+                    std::string *output)
+{
+    if (output == nullptr)
+        return false;
+    if (data == nullptr && len != 0)
+        return fail(output);
 
-            for(i = 0; (i <4) ; i++)
-                ret += base64_chars[char_array_4[i]];
-            i = 0;
-        }
-    }
+    std::string encoded;
+    const size_t groups = len / 3 + (len % 3 == 0 ? 0 : 1);
+    if (groups > encoded.max_size() / 4)
+        return fail(output);
+    encoded.reserve(groups * 4);
 
-    if (i)
+    size_t offset = 0;
+    while (len - offset >= 3)
     {
-        for(j = i; j < 3; j++)
-            char_array_3[j] = '\0';
-
-        char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
-        char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
-        char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
-        char_array_4[3] = char_array_3[2] & 0x3f;
-
-        for (j = 0; (j < i + 1); j++)
-            ret += base64_chars[char_array_4[j]];
-
-        while((i++ < 3))
-            ret += '=';
-
+        const unsigned int first = data[offset];
+        const unsigned int second = data[offset + 1];
+        const unsigned int third = data[offset + 2];
+        encoded.push_back(base64_chars[first >> 2]);
+        encoded.push_back(base64_chars[((first & 0x03U) << 4) |
+                                       (second >> 4)]);
+        encoded.push_back(base64_chars[((second & 0x0FU) << 2) |
+                                       (third >> 6)]);
+        encoded.push_back(base64_chars[third & 0x3FU]);
+        offset += 3;
     }
 
-    return ret;
+    const size_t remaining = len - offset;
+    if (remaining == 1)
+    {
+        const unsigned int first = data[offset];
+        encoded.push_back(base64_chars[first >> 2]);
+        encoded.push_back(base64_chars[(first & 0x03U) << 4]);
+        encoded.append("==");
+    }
+    else if (remaining == 2)
+    {
+        const unsigned int first = data[offset];
+        const unsigned int second = data[offset + 1];
+        encoded.push_back(base64_chars[first >> 2]);
+        encoded.push_back(base64_chars[((first & 0x03U) << 4) |
+                                       (second >> 4)]);
+        encoded.push_back(base64_chars[(second & 0x0FU) << 2]);
+        encoded.push_back('=');
+    }
+
+    *output = std::move(encoded);
+    return true;
 }
 
-std::string Base64::decode(const std::string &encoded_string)
+std::string Base64::decode(const std::string& encoded_string)
 {
-    int in_len = encoded_string.size();
-    int i = 0;
-    int j = 0;
-    int in_ = 0;
-    unsigned char char_array_4[4], char_array_3[3];
-    std::string ret;
+    std::string output;
+    (void)decode(encoded_string, &output);
+    return output;
+}
 
-    while (in_len-- && ( encoded_string[in_] != '=') && is_base64(encoded_string[in_])) {
-        char_array_4[i++] = encoded_string[in_]; in_++;
-        if (i ==4) {
-            for (i = 0; i <4; i++)
-                char_array_4[i] = base64_chars.find(char_array_4[i]);
+bool Base64::decode(const std::string& encoded_string,
+                    std::string *output)
+{
+    if (output == nullptr)
+        return false;
 
-            char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
-            char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
-            char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+    const size_t length = encoded_string.size();
+    size_t padding = 0;
+    while (padding < length &&
+           encoded_string[length - padding - 1] == '=')
+    {
+        ++padding;
+    }
+    if (padding > 2)
+        return fail(output);
 
-            for (i = 0; (i < 3); i++)
-                ret += char_array_3[i];
-            i = 0;
+    const size_t data_length = length - padding;
+    const size_t remainder = data_length % 4;
+    if (remainder == 1 ||
+        (padding != 0 && length % 4 != 0) ||
+        (padding == 1 && remainder != 3) ||
+        (padding == 2 && remainder != 2))
+    {
+        return fail(output);
+    }
+
+    for (size_t i = 0; i < data_length; ++i)
+    {
+        if (base64_value(
+                static_cast<unsigned char>(encoded_string[i])) < 0)
+        {
+            return fail(output);
         }
     }
 
-    if (i) {
-        for (j = i; j <4; j++)
-            char_array_4[j] = 0;
-
-        for (j = 0; j <4; j++)
-            char_array_4[j] = base64_chars.find(char_array_4[j]);
-
-        char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
-        char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
-        char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
-
-        for (j = 0; (j < i - 1); j++) ret += char_array_3[j];
+    if (remainder == 2)
+    {
+        const int value = base64_value(
+            static_cast<unsigned char>(encoded_string[data_length - 1]));
+        if ((value & 0x0F) != 0)
+            return fail(output);
+    }
+    else if (remainder == 3)
+    {
+        const int value = base64_value(
+            static_cast<unsigned char>(encoded_string[data_length - 1]));
+        if ((value & 0x03) != 0)
+            return fail(output);
     }
 
-    return ret;
+    std::string decoded;
+    const size_t complete_groups = data_length / 4;
+    if (complete_groups > decoded.max_size() / 3)
+        return fail(output);
+    const size_t complete_size = complete_groups * 3;
+    const size_t tail_size = remainder == 0 ? 0 : remainder - 1;
+    if (tail_size > decoded.max_size() - complete_size)
+        return fail(output);
+    decoded.reserve(complete_size + tail_size);
+
+    size_t offset = 0;
+    for (size_t group = 0; group < complete_groups; ++group)
+    {
+        const unsigned int first = static_cast<unsigned int>(base64_value(
+            static_cast<unsigned char>(encoded_string[offset])));
+        const unsigned int second = static_cast<unsigned int>(base64_value(
+            static_cast<unsigned char>(encoded_string[offset + 1])));
+        const unsigned int third = static_cast<unsigned int>(base64_value(
+            static_cast<unsigned char>(encoded_string[offset + 2])));
+        const unsigned int fourth = static_cast<unsigned int>(base64_value(
+            static_cast<unsigned char>(encoded_string[offset + 3])));
+        decoded.push_back(static_cast<char>((first << 2) | (second >> 4)));
+        decoded.push_back(static_cast<char>((second << 4) | (third >> 2)));
+        decoded.push_back(static_cast<char>((third << 6) | fourth));
+        offset += 4;
+    }
+
+    if (remainder >= 2)
+    {
+        const unsigned int first = static_cast<unsigned int>(base64_value(
+            static_cast<unsigned char>(encoded_string[offset])));
+        const unsigned int second = static_cast<unsigned int>(base64_value(
+            static_cast<unsigned char>(encoded_string[offset + 1])));
+        decoded.push_back(static_cast<char>((first << 2) | (second >> 4)));
+
+        if (remainder == 3)
+        {
+            const unsigned int third = static_cast<unsigned int>(base64_value(
+                static_cast<unsigned char>(encoded_string[offset + 2])));
+            decoded.push_back(
+                static_cast<char>((second << 4) | (third >> 2)));
+        }
+    }
+
+    *output = std::move(decoded);
+    return true;
 }
+
+} // namespace wfrest

--- a/src/base/base64.h
+++ b/src/base/base64.h
@@ -2,6 +2,7 @@
 #ifndef WFREST_BASE64_H_
 #define WFREST_BASE64_H_
 
+#include <cstddef>
 #include <string>
 
 namespace wfrest
@@ -12,7 +13,14 @@ class Base64
 public:
     static std::string encode(const unsigned char *bytes_to_encode, unsigned int len);
 
+    static bool encode(const unsigned char *data,
+                       size_t len,
+                       std::string *output);
+
     static std::string decode(std::string const &encoded_string);
+
+    static bool decode(const std::string& encoded_string,
+                       std::string *output);
 
 private:
     static const std::string base64_chars;

--- a/test/base64_unittest.cc
+++ b/test/base64_unittest.cc
@@ -1,32 +1,146 @@
 #include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
 #include "wfrest/base64.h"
 
 using namespace wfrest;
 
-TEST(base64, shortText)
+namespace
 {
-    std::string source = "wfrest http framework";
 
-    std::string encode = Base64::encode(
-                        reinterpret_cast<const unsigned char *>(source.data()),
-                        source.size());
-    EXPECT_EQ(encode, "d2ZyZXN0IGh0dHAgZnJhbWV3b3Jr");
-    std::string decode = Base64::decode(encode);
-    EXPECT_EQ(source, decode);
+struct Base64Vector
+{
+    const char *plain;
+    const char *encoded;
+    const char *unpadded;
+};
+
+const Base64Vector kVectors[] = {
+    {"", "", ""},
+    {"f", "Zg==", "Zg"},
+    {"fo", "Zm8=", "Zm8"},
+    {"foo", "Zm9v", "Zm9v"},
+    {"foob", "Zm9vYg==", "Zm9vYg"},
+    {"fooba", "Zm9vYmE=", "Zm9vYmE"},
+    {"foobar", "Zm9vYmFy", "Zm9vYmFy"}
+};
+
+} // namespace
+
+TEST(Base64, matches_known_padded_and_unpadded_vectors)
+{
+    for (const Base64Vector& vector : kVectors)
+    {
+        SCOPED_TRACE(vector.plain);
+        const std::string plain = vector.plain;
+        EXPECT_EQ(Base64::encode(
+                      reinterpret_cast<const unsigned char *>(plain.data()),
+                      static_cast<unsigned int>(plain.size())),
+                  vector.encoded);
+
+        std::string decoded = "stale";
+        EXPECT_TRUE(Base64::decode(vector.encoded, &decoded));
+        EXPECT_EQ(decoded, plain);
+        EXPECT_TRUE(Base64::decode(vector.unpadded, &decoded));
+        EXPECT_EQ(decoded, plain);
+        EXPECT_EQ(Base64::decode(vector.encoded), plain);
+    }
 }
 
-TEST(base64, longText)
+TEST(Base64, round_trips_all_bytes_and_group_boundaries)
 {
-    std::string source;
-    source.reserve(100000);
-    for (int i = 0; i < 100000; ++i)
+    std::string all_bytes;
+    for (unsigned int byte = 0; byte <= 0xFFU; ++byte)
+        all_bytes.push_back(static_cast<char>(byte));
+
+    for (size_t size = 0; size <= all_bytes.size(); ++size)
     {
-        source.append(1, char(i));
+        SCOPED_TRACE(size);
+        const std::string source = all_bytes.substr(0, size);
+        std::string encoded;
+        ASSERT_TRUE(Base64::encode(
+            reinterpret_cast<const unsigned char *>(source.data()),
+            source.size(),
+            &encoded));
+        std::string decoded;
+        ASSERT_TRUE(Base64::decode(encoded, &decoded));
+        EXPECT_EQ(decoded, source);
     }
 
-    std::string encode = Base64::encode(
-                        reinterpret_cast<const unsigned char *>(source.data()),
-                        source.size());
-    std::string decode = Base64::decode(encode);
-    EXPECT_EQ(source, decode);
+    std::string long_source;
+    long_source.reserve(100000);
+    for (size_t i = 0; i < 100000; ++i)
+        long_source.push_back(static_cast<char>(i & 0xFFU));
+    std::string long_encoded;
+    ASSERT_TRUE(Base64::encode(
+        reinterpret_cast<const unsigned char *>(long_source.data()),
+        long_source.size(),
+        &long_encoded));
+    std::string long_decoded;
+    ASSERT_TRUE(Base64::decode(long_encoded, &long_decoded));
+    EXPECT_EQ(long_decoded, long_source);
+}
+
+TEST(Base64, supports_checked_input_output_aliases)
+{
+    const std::string original = "raw input backed by output";
+    std::string value = original;
+    ASSERT_TRUE(Base64::encode(
+        reinterpret_cast<const unsigned char *>(value.data()),
+        value.size(),
+        &value));
+    EXPECT_NE(value, original);
+
+    ASSERT_TRUE(Base64::decode(value, &value));
+    EXPECT_EQ(value, original);
+}
+
+TEST(Base64, validates_null_boundaries)
+{
+    std::string output = "stale";
+    EXPECT_FALSE(Base64::encode(nullptr, 1, &output));
+    EXPECT_TRUE(output.empty());
+
+    output = "stale";
+    EXPECT_TRUE(Base64::encode(nullptr, 0, &output));
+    EXPECT_TRUE(output.empty());
+
+    EXPECT_FALSE(Base64::encode(nullptr, 0, nullptr));
+    EXPECT_FALSE(Base64::decode("", nullptr));
+    EXPECT_TRUE(Base64::encode(nullptr, 1).empty());
+}
+
+TEST(Base64, rejects_complete_malformed_input_without_prefixes)
+{
+    const std::vector<std::string> invalid = {
+        "A", "AAAAA", "TWFu$admin", "TWFu\n", "T WFu", "TWFu\r\n",
+        "TQ=evil",
+        "TQ===", "=TQ=", "T=Q=", "AA=A", "-w==", "_w==",
+        "AB==", "AB", "AAB=", "AAB",
+        std::string("AA\0A", 4),
+        std::string(1, static_cast<char>(0xFF))};
+
+    for (const std::string& encoded : invalid)
+    {
+        SCOPED_TRACE(encoded);
+        std::string output = "stale";
+        EXPECT_FALSE(Base64::decode(encoded, &output));
+        EXPECT_TRUE(output.empty());
+        EXPECT_TRUE(Base64::decode(encoded).empty());
+    }
+}
+
+TEST(Base64, accepts_canonical_final_bits)
+{
+    const std::vector<std::string> valid = {
+        "AA==", "AA", "AAA=", "AAA", "/w==", "/w", "//8=", "//8"};
+
+    for (const std::string& encoded : valid)
+    {
+        SCOPED_TRACE(encoded);
+        std::string output;
+        EXPECT_TRUE(Base64::decode(encoded, &output));
+    }
 }


### PR DESCRIPTION
## Why

The old decoder stopped at padding/invalid bytes and returned a decoded prefix, making malformed values such as `TWFu$admin` equivalent to clean `TWFu`. It also accepted excess/middle padding, impossible tail lengths, and non-zero unused bits; the encoder dereferenced null input when length was non-zero.

The fixed checked probe now reports success only for `TWFu` and `TQ==`; invalid suffixes, padding, one-character tails, and `AB==` all return `false` with an empty output. `encode(nullptr, 1)` no longer triggers sanitizers.

This implements spec PR #353 and tracks issue #352.

## Plan implemented

1. Add checked `bool encode(..., size_t, string*)` and `bool decode(..., string*)` APIs.
2. Stage results for raw/string input-output alias safety and clear valid outputs on failure.
3. Validate null pointers and output-size arithmetic before reads/reserves.
4. Replace locale-sensitive classification and `find()` narrowing with exact ASCII sextet mapping.
5. Validate every byte, padding suffix/count, final group length, and zero unused bits.
6. Accept canonical padded/unpadded forms; reject whitespace, URL-safe characters, high/embedded-invalid bytes, and malformed suffixes.
7. Delegate legacy APIs so invalid decode returns no prefix.
8. Expand tests with standard vectors, all 256 bytes, 0–256 boundaries, 100k binary input, aliases, nulls, and malformed/canonical tables.

## Compatibility

- Existing public signatures and valid standard Base64 bytes remain unchanged.
- Canonical unpadded input remains accepted.
- Only malformed/non-canonical prefix-decoding behavior tightens.
- Checked callers can distinguish valid empty output from failure and use `size_t` encoding lengths.

## Validation

- Fixed ASan/UBSan probe: malformed cases fail wholly; null encode is safe.
- Strict production compile: C++11, `-Wall -Wextra -Wpedantic -Werror`.
- Strict test compile: C++14, `-Wall -Wextra -Wpedantic -Werror`, exceptions disabled.
- Focused ordinary Base64 test passes.
- ASan + UBSan focused Base64 test passes.
- Full ordinary suite: 37/37 tests pass.

Issue: #352
Spec: #353
