### PR TITLE
fix(timestamp): saturate arithmetic boundaries

### DIFF
--- a/src/base/Timestamp.cc
+++ b/src/base/Timestamp.cc
@@ -88,8 +88,11 @@ void Timestamp::swap(Timestamp &that)
 
 std::string Timestamp::to_str() const
 {
-    return std::to_string(micro_sec_since_epoch_ / k_micro_sec_per_sec)
-           + "." + std::to_string(micro_sec_since_epoch_ % k_micro_sec_per_sec);
+    std::stringstream stream;
+    stream << micro_sec_since_epoch_ / k_micro_sec_per_sec << '.'
+           << std::setfill('0') << std::setw(6)
+           << micro_sec_since_epoch_ % k_micro_sec_per_sec;
+    return stream.str();
 }
 
 std::string Timestamp::to_format_str() const

--- a/src/base/Timestamp.h
+++ b/src/base/Timestamp.h
@@ -2,6 +2,8 @@
 #define WFREST_TIMESTAMP_H_
 
 #include <chrono>
+#include <cmath>
+#include <limits>
 #include <string>
 #include <sstream>
 #include <iomanip> // put_time
@@ -81,32 +83,66 @@ inline bool operator!=(Timestamp lhs, Timestamp rhs)
     return lhs.micro_sec_since_epoch() != rhs.micro_sec_since_epoch();
 }
 
-inline Timestamp operator+(Timestamp lhs, uint64_t ms)
+inline Timestamp operator+(Timestamp lhs, uint64_t microseconds)
 {
-    return Timestamp(lhs.micro_sec_since_epoch() + ms);
+    const uint64_t current = lhs.micro_sec_since_epoch();
+    const uint64_t maximum = std::numeric_limits<uint64_t>::max();
+    if (microseconds > maximum - current)
+        return Timestamp(maximum);
+    return Timestamp(current + microseconds);
 }
 
 inline Timestamp operator+(Timestamp lhs, double seconds)
 {
-    uint64_t delta = static_cast<uint64_t>(seconds * Timestamp::k_micro_sec_per_sec);
-    return Timestamp(lhs.micro_sec_since_epoch() + delta);
+    if (std::isnan(seconds) || seconds == 0.0)
+        return lhs;
+
+    const bool add = seconds > 0.0;
+    const long double magnitude =
+        (add ? static_cast<long double>(seconds) :
+               -static_cast<long double>(seconds)) *
+        Timestamp::k_micro_sec_per_sec;
+    const uint64_t current = lhs.micro_sec_since_epoch();
+
+    if (add)
+    {
+        const uint64_t maximum = std::numeric_limits<uint64_t>::max();
+        const uint64_t room = maximum - current;
+        if (magnitude >= static_cast<long double>(room))
+            return Timestamp(maximum);
+        return Timestamp(current + static_cast<uint64_t>(magnitude));
+    }
+
+    if (magnitude >= static_cast<long double>(current))
+        return Timestamp();
+    return Timestamp(current - static_cast<uint64_t>(magnitude));
 }
 
-inline Timestamp operator-(Timestamp lhs, uint64_t ms)
+inline Timestamp operator-(Timestamp lhs, uint64_t microseconds)
 {
-    return Timestamp(lhs.micro_sec_since_epoch() - ms);
+    const uint64_t current = lhs.micro_sec_since_epoch();
+    if (microseconds > current)
+        return Timestamp();
+    return Timestamp(current - microseconds);
 }
 
 inline Timestamp operator-(Timestamp lhs, double seconds)
 {
-    uint64_t delta = static_cast<uint64_t>(seconds * Timestamp::k_micro_sec_per_sec);
-    return Timestamp(lhs.micro_sec_since_epoch() - delta);
+    return lhs + -seconds;
 }
 
 inline double operator-(Timestamp high, Timestamp low)
 {
-    uint64_t diff = high.micro_sec_since_epoch() - low.micro_sec_since_epoch();
-    return static_cast<double>(diff) / Timestamp::k_micro_sec_per_sec;
+    if (high >= low)
+    {
+        const uint64_t diff =
+            high.micro_sec_since_epoch() - low.micro_sec_since_epoch();
+        return static_cast<double>(diff) / Timestamp::k_micro_sec_per_sec;
+    }
+
+    const uint64_t diff =
+        low.micro_sec_since_epoch() - high.micro_sec_since_epoch();
+    return -static_cast<double>(diff) / Timestamp::k_micro_sec_per_sec;
 }
 
 }  // namespace wfrest

--- a/test/TimeStamp_unittest.cc
+++ b/test/TimeStamp_unittest.cc
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <locale>
+#include <limits>
 #include <string>
 #include <thread>
 #include <vector>
@@ -79,6 +80,76 @@ private:
 };
 
 } // namespace
+
+TEST(Timestamp, serializes_exact_microsecond_fraction)
+{
+    EXPECT_EQ(Timestamp(0).to_str(), "0.000000");
+    EXPECT_EQ(Timestamp(1).to_str(), "0.000001");
+    EXPECT_EQ(Timestamp(1000001).to_str(), "1.000001");
+    EXPECT_EQ(Timestamp(1100000).to_str(), "1.100000");
+}
+
+TEST(Timestamp, saturates_integer_timepoint_arithmetic)
+{
+    const uint64_t maximum = std::numeric_limits<uint64_t>::max();
+
+    EXPECT_EQ((Timestamp(10) + static_cast<uint64_t>(5))
+                  .micro_sec_since_epoch(), 15U);
+    EXPECT_EQ((Timestamp(maximum - 1) + static_cast<uint64_t>(1))
+                  .micro_sec_since_epoch(), maximum);
+    EXPECT_EQ((Timestamp(maximum - 1) + static_cast<uint64_t>(2))
+                  .micro_sec_since_epoch(), maximum);
+
+    EXPECT_EQ((Timestamp(10) - static_cast<uint64_t>(5))
+                  .micro_sec_since_epoch(), 5U);
+    EXPECT_EQ((Timestamp(5) - static_cast<uint64_t>(5))
+                  .micro_sec_since_epoch(), 0U);
+    EXPECT_EQ((Timestamp(5) - static_cast<uint64_t>(6))
+                  .micro_sec_since_epoch(), 0U);
+}
+
+TEST(Timestamp, applies_floating_seconds_without_invalid_casts)
+{
+    const Timestamp base(2000000);
+    EXPECT_EQ((base + 1.5).micro_sec_since_epoch(), 3500000U);
+    EXPECT_EQ((base - 1.5).micro_sec_since_epoch(), 500000U);
+    EXPECT_EQ((base + -1.5).micro_sec_since_epoch(), 500000U);
+    EXPECT_EQ((base - -1.5).micro_sec_since_epoch(), 3500000U);
+    EXPECT_EQ((base + 0.0000009).micro_sec_since_epoch(), 2000000U);
+    EXPECT_EQ((base + 0.0000019).micro_sec_since_epoch(), 2000001U);
+
+    const double infinity = std::numeric_limits<double>::infinity();
+    const double maximum = std::numeric_limits<double>::max();
+    const uint64_t max_timestamp = std::numeric_limits<uint64_t>::max();
+    EXPECT_EQ((base + infinity).micro_sec_since_epoch(), max_timestamp);
+    EXPECT_EQ((base + -infinity).micro_sec_since_epoch(), 0U);
+    EXPECT_EQ((base - infinity).micro_sec_since_epoch(), 0U);
+    EXPECT_EQ((base - -infinity).micro_sec_since_epoch(), max_timestamp);
+    EXPECT_EQ((base + maximum).micro_sec_since_epoch(), max_timestamp);
+    EXPECT_EQ((base + -maximum).micro_sec_since_epoch(), 0U);
+
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_EQ((base + nan).micro_sec_since_epoch(),
+              base.micro_sec_since_epoch());
+    EXPECT_EQ((base - nan).micro_sec_since_epoch(),
+              base.micro_sec_since_epoch());
+}
+
+TEST(Timestamp, computes_signed_duration_differences)
+{
+    const Timestamp early(1000000);
+    const Timestamp late(2000000);
+    EXPECT_DOUBLE_EQ(late - early, 1.0);
+    EXPECT_DOUBLE_EQ(early - late, -1.0);
+    EXPECT_DOUBLE_EQ(early - early, 0.0);
+
+    const Timestamp maximum(std::numeric_limits<uint64_t>::max());
+    const double forward = maximum - Timestamp();
+    const double reverse = Timestamp() - maximum;
+    EXPECT_GT(forward, 0.0);
+    EXPECT_LT(reverse, 0.0);
+    EXPECT_DOUBLE_EQ(forward, -reverse);
+}
 
 TEST(Timestamp, separates_local_and_utc_formatting)
 {


### PR DESCRIPTION
Closes #355

## Why

`Timestamp` stores unsigned epoch microseconds, but its arithmetic currently wraps at both endpoints. Negative or oversized floating-second deltas are also cast outside the `uint64_t` domain, which is undefined behavior. Separately, `to_str()` drops leading/trailing fractional zeros, and reverse timestamp subtraction reports a huge positive duration.

## Plan

- serialize the fractional field as exactly six microsecond digits;
- pre-check integer addition/subtraction and saturate at zero or `UINT64_MAX`;
- classify floating deltas by sign and magnitude in `long double` before any unsigned conversion;
- define zero/NaN as unchanged and infinite/oversized values as endpoint saturation;
- compute timestamp differences in an ordered branch so reverse durations are negative;
- add boundary, precision, infinity, NaN, and antisymmetry tests.

## Compatibility

Public signatures and integer microsecond units stay unchanged. In-range positive arithmetic retains truncation toward zero. Only previously wrapped, undefined, or ambiguous boundary/text behavior changes.

## Validation

- focused `TimeStamp_unittest`;
- strict C++11 production and C++14 test warning-as-error compilation;
- ASan + UBSan + `float-cast-overflow` focused run;
- standalone reproducer under `float-cast-overflow`;
- full CTest suite: 37/37 passed;
- `git diff --check`.

Spec: #356