### PR TITLE
fix(multipart): validate part header grammar

### DIFF
--- a/src/core/MultiPartParser.c
+++ b/src/core/MultiPartParser.c
@@ -40,6 +40,31 @@ do {                                                                   \
 #define LF 10
 #define CR 13
 
+static int is_header_field_char(unsigned char c)
+{
+    if ((c >= '0' && c <= '9') ||
+        (c >= 'A' && c <= 'Z') ||
+        (c >= 'a' && c <= 'z'))
+    {
+        return 1;
+    }
+
+    switch (c)
+    {
+        case '!': case '#': case '$': case '%': case '&': case '\'':
+        case '*': case '+': case '-': case '.': case '^': case '_':
+        case '`': case '|': case '~':
+            return 1;
+        default:
+            return 0;
+    }
+}
+
+static int is_header_value_char(unsigned char c)
+{
+    return c == '\t' || (c >= 0x20 && c <= 0x7e) || c >= 0x80;
+}
+
 struct multipart_parser
 {
     void *data;
@@ -131,7 +156,7 @@ size_t multipart_parser_execute(multipart_parser *p, const char *buf, size_t len
 {
     size_t i = 0;
     size_t mark = 0;
-    char c, cl;
+    char c;
     int is_last = 0;
 
     if (p == NULL || (buf == NULL && len != 0))
@@ -180,30 +205,35 @@ size_t multipart_parser_execute(multipart_parser *p, const char *buf, size_t len
             case s_header_field_start:
                 multipart_log("s_header_field_start");
                 mark = i;
+                p->index = 0;
+                if (c == CR)
+                {
+                    p->state = s_headers_almost_done;
+                    break;
+                }
                 p->state = s_header_field;
 
                 /* fallthrough */
             case s_header_field:
                 multipart_log("s_header_field");
                 if (c == CR)
-                {
-                    p->state = s_headers_almost_done;
-                    break;
-                }
+                    return i;
 
                 if (c == ':')
                 {
+                    if (p->index == 0)
+                        return i;
                     EMIT_DATA_CB(header_field, buf + mark, i - mark);
                     p->state = s_header_value_start;
                     break;
                 }
 
-                cl = (char) tolower((unsigned char) c);
-                if ((c != '-') && (cl < 'a' || cl > 'z'))
+                if (!is_header_field_char((unsigned char) c))
                 {
                     multipart_log("invalid character in header name");
                     return i;
                 }
+                p->index++;
                 if (is_last)
                     EMIT_DATA_CB(header_field, buf + mark, (i - mark) + 1);
                 break;
@@ -220,7 +250,7 @@ size_t multipart_parser_execute(multipart_parser *p, const char *buf, size_t len
 
             case s_header_value_start:
                 multipart_log("s_header_value_start");
-                if (c == ' ')
+                if (c == ' ' || c == '\t')
                 {
                     break;
                 }
@@ -236,6 +266,11 @@ size_t multipart_parser_execute(multipart_parser *p, const char *buf, size_t len
                     EMIT_DATA_CB(header_value, buf + mark, i - mark);
                     p->state = s_header_value_almost_done;
                     break;
+                }
+                if (!is_header_value_char((unsigned char) c))
+                {
+                    multipart_log("invalid character in header value");
+                    return i;
                 }
                 if (is_last)
                     EMIT_DATA_CB(header_value, buf + mark, (i - mark) + 1);

--- a/test/HttpContent_unittest.cc
+++ b/test/HttpContent_unittest.cc
@@ -31,6 +31,38 @@ std::string multipart_disposition_body(const std::string &boundary,
            "\r\n\r\n" + value + "\r\n--" + boundary + "--\r\n";
 }
 
+std::string multipart_extra_header_body(const std::string &boundary,
+                                        const std::string &header)
+{
+    return "--" + boundary +
+           "\r\nContent-Disposition: form-data; name=item\r\n" +
+           header + "\r\n\r\nvalue\r\n--" + boundary + "--\r\n";
+}
+
+struct MultipartCallbackState
+{
+    std::string header_field;
+    bool body_ended = false;
+};
+
+int collect_header_field(multipart_parser *parser,
+                         const char *data,
+                         size_t size)
+{
+    auto *state = static_cast<MultipartCallbackState *>(
+        multipart_parser_get_data(parser));
+    state->header_field.append(data, size);
+    return 0;
+}
+
+int mark_body_end(multipart_parser *parser)
+{
+    auto *state = static_cast<MultipartCallbackState *>(
+        multipart_parser_get_data(parser));
+    state->body_ended = true;
+    return 0;
+}
+
 } // namespace
 
 TEST(Urlencode, parse_post_kv)
@@ -199,6 +231,88 @@ TEST(MultiPartForm, rejects_invalid_content_disposition_metadata)
         "Content-Disposition: form-data; name=second\r\n"
         "\r\nvalue\r\n--abc--\r\n";
     EXPECT_TRUE(parser.parse_multipart(StringPiece(duplicate_header)).empty());
+}
+
+TEST(MultiPartForm, accepts_http_token_part_header_names)
+{
+    MultiPartForm parser;
+    parser.set_boundary("abc");
+
+    const std::vector<std::string> headers = {
+        "Content-MD5: digest",
+        "X-Trace_1: value",
+        "!#$%&'*+-.^_`|~: punctuation",
+        "X-Empty:\t ",
+        std::string("X-Bytes: visible\t") +
+            static_cast<char>(0x80) + static_cast<char>(0xff)
+    };
+
+    for (const std::string &header : headers)
+    {
+        const Form form = parser.parse_multipart(StringPiece(
+            multipart_extra_header_body("abc", header)));
+        ASSERT_EQ(form.size(), 1U) << header;
+        EXPECT_EQ(form.at("item").second, "value");
+    }
+}
+
+TEST(MultiPartForm, rejects_malformed_part_header_lines)
+{
+    MultiPartForm parser;
+    parser.set_boundary("abc");
+
+    std::vector<std::string> headers = {
+        ": empty",
+        "Missing-Colon",
+        "Bad Name: value",
+        "Bad\tName: value",
+        "Bad(Name): value",
+        "X-Test: ok\nInjected: yes"
+    };
+
+    std::string invalid_name = "X-Bad";
+    invalid_name.push_back(static_cast<char>(0x80));
+    invalid_name += ": value";
+    headers.push_back(invalid_name);
+
+    for (unsigned char byte : {0x00, 0x01, 0x08, 0x0b, 0x1f, 0x7f})
+    {
+        std::string invalid_value = "X-Test: before";
+        invalid_value.push_back(static_cast<char>(byte));
+        invalid_value += "after";
+        headers.push_back(invalid_value);
+    }
+
+    for (const std::string &header : headers)
+    {
+        EXPECT_TRUE(parser.parse_multipart(StringPiece(
+            multipart_extra_header_body("abc", header))).empty());
+    }
+}
+
+TEST(MultiPartParser, preserves_field_name_state_between_input_buffers)
+{
+    multipart_parser_settings settings = {};
+    settings.on_header_field = collect_header_field;
+    settings.on_body_end = mark_body_end;
+
+    multipart_parser *parser = multipart_parser_init("--abc", &settings);
+    ASSERT_NE(parser, nullptr);
+
+    MultipartCallbackState state;
+    multipart_parser_set_data(parser, &state);
+    const std::vector<std::string> chunks = {
+        "--abc\r\nX-Trace",
+        "_1",
+        ": value\r\n\r\ndata\r\n--abc--\r\n"
+    };
+    for (const std::string &chunk : chunks)
+        EXPECT_EQ(multipart_parser_execute(parser, chunk.data(), chunk.size()),
+                  chunk.size());
+
+    EXPECT_EQ(state.header_field, "X-Trace_1");
+    EXPECT_TRUE(state.body_ended);
+    multipart_parser_free(parser);
 }
 
 TEST(MultiPartForm, isolates_invalid_disposition_between_parts)


### PR DESCRIPTION
Closes #358

## Why

Multipart part headers were checked against two inconsistent languages: legal HTTP token names containing digits or punctuation were rejected, while empty names and unsafe controls in values were accepted. This broke valid uploads and allowed malformed lines through a parser trust boundary.

## Plan

- recognize the complete ASCII `tchar` set;
- require at least one field-name byte and retain that count across execute buffers;
- distinguish a blank header terminator from a nonempty name missing `:`;
- accept SP, HTAB, visible ASCII, and obs-text in values while rejecting bare LF, NUL/control bytes, and DEL;
- treat both SP and HTAB as leading optional whitespace;
- add form-level valid/invalid grammar tests plus a three-buffer low-level parser test.

## Compatibility

Public C/C++ signatures, boundary parsing, callback fragmentation, and `Content-Disposition` behavior are unchanged. Valid token names become accepted; syntactically malformed ignored headers now reject the body.

## Validation

- original probe: `0,0,1,1` before → `1,1,0,0` after;
- focused `HttpContent_unittest`: 11/11 passed;
- strict C11 parser and C++14 test compilation with `-Werror`;
- ASan + UBSan focused suite: 11/11 passed with leak detection;
- full CTest suite: 37/37 passed;
- `git diff --check`.

Spec: #359