### PR TITLE
fix(http): bound Keep-Alive request policy

### DIFF
--- a/src/core/HttpKeepAliveUtil.h
+++ b/src/core/HttpKeepAliveUtil.h
@@ -1,0 +1,185 @@
+#ifndef WFREST_HTTPKEEPALIVEUTIL_H_
+#define WFREST_HTTPKEEPALIVEUTIL_H_
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <string>
+
+namespace wfrest
+{
+namespace detail
+{
+
+constexpr int k_keep_alive_timeout_max_ms = 300 * 1000;
+
+inline bool is_keep_alive_ows(char ch)
+{
+    return ch == ' ' || ch == '\t';
+}
+
+inline void trim_keep_alive_ows(const std::string &value,
+                                size_t *begin,
+                                size_t *end)
+{
+    while (*begin < *end && is_keep_alive_ows(value[*begin]))
+        ++*begin;
+    while (*end > *begin && is_keep_alive_ows(value[*end - 1]))
+        --*end;
+}
+
+inline unsigned char keep_alive_ascii_lower(unsigned char ch)
+{
+    if (ch >= 'A' && ch <= 'Z')
+        return static_cast<unsigned char>(ch + ('a' - 'A'));
+    return ch;
+}
+
+inline bool keep_alive_key_equals(const std::string &value,
+                                  size_t begin,
+                                  size_t end,
+                                  const char *expected)
+{
+    size_t cursor = begin;
+    size_t expected_cursor = 0;
+    while (cursor < end && expected[expected_cursor] != '\0')
+    {
+        if (keep_alive_ascii_lower(
+                static_cast<unsigned char>(value[cursor])) !=
+            keep_alive_ascii_lower(
+                static_cast<unsigned char>(expected[expected_cursor])))
+        {
+            return false;
+        }
+        ++cursor;
+        ++expected_cursor;
+    }
+
+    return cursor == end && expected[expected_cursor] == '\0';
+}
+
+inline bool parse_keep_alive_decimal(const std::string &value,
+                                     size_t begin,
+                                     size_t end,
+                                     uint64_t limit,
+                                     uint64_t *result)
+{
+    if (begin == end)
+        return false;
+
+    uint64_t parsed = 0;
+    for (size_t cursor = begin; cursor < end; ++cursor)
+    {
+        const unsigned char ch =
+            static_cast<unsigned char>(value[cursor]);
+        if (ch < '0' || ch > '9')
+            return false;
+
+        const uint64_t digit = static_cast<uint64_t>(ch - '0');
+        if (parsed > limit / 10 ||
+            (parsed == limit / 10 && digit > limit % 10))
+        {
+            parsed = limit;
+        }
+        else
+        {
+            parsed = parsed * 10 + digit;
+        }
+    }
+
+    *result = parsed;
+    return true;
+}
+
+inline int resolve_keep_alive_timeout(const std::string &header_value,
+                                      long long connection_sequence,
+                                      int configured_timeout_ms)
+{
+    int timeout_ms = configured_timeout_ms;
+    if (timeout_ms < 0 || timeout_ms > k_keep_alive_timeout_max_ms)
+        timeout_ms = k_keep_alive_timeout_max_ms;
+
+    bool has_timeout = false;
+    bool has_max = false;
+    uint64_t max_requests = 0;
+
+    size_t segment_begin = 0;
+    while (segment_begin <= header_value.size())
+    {
+        size_t segment_end = header_value.find(',', segment_begin);
+        if (segment_end == std::string::npos)
+            segment_end = header_value.size();
+
+        size_t begin = segment_begin;
+        size_t end = segment_end;
+        trim_keep_alive_ows(header_value, &begin, &end);
+
+        const size_t equals = header_value.find('=', begin);
+        if (equals < end)
+        {
+            size_t key_begin = begin;
+            size_t key_end = equals;
+            trim_keep_alive_ows(header_value, &key_begin, &key_end);
+
+            size_t value_begin = equals + 1;
+            size_t value_end = end;
+            trim_keep_alive_ows(header_value, &value_begin, &value_end);
+
+            if (!has_timeout && keep_alive_key_equals(
+                    header_value, key_begin, key_end, "timeout"))
+            {
+                uint64_t seconds;
+                if (parse_keep_alive_decimal(header_value,
+                                             value_begin,
+                                             value_end,
+                                             300,
+                                             &seconds))
+                {
+                    has_timeout = true;
+                    const int requested_ms =
+                        static_cast<int>(seconds * 1000);
+                    timeout_ms = std::min(timeout_ms, requested_ms);
+                }
+            }
+            else if (!has_max && keep_alive_key_equals(
+                         header_value, key_begin, key_end, "max"))
+            {
+                uint64_t parsed_max;
+                if (parse_keep_alive_decimal(
+                        header_value,
+                        value_begin,
+                        value_end,
+                        std::numeric_limits<uint64_t>::max(),
+                        &parsed_max))
+                {
+                    has_max = true;
+                    max_requests = parsed_max;
+                }
+            }
+        }
+
+        if (segment_end == header_value.size())
+            break;
+        segment_begin = segment_end + 1;
+    }
+
+    if (has_max)
+    {
+        uint64_t request_ordinal = 1;
+        if (connection_sequence >= 0)
+        {
+            request_ordinal =
+                static_cast<uint64_t>(connection_sequence) + 1;
+        }
+
+        if (request_ordinal >= max_requests)
+            timeout_ms = 0;
+    }
+
+    return timeout_ms;
+}
+
+} // namespace detail
+} // namespace wfrest
+
+#endif // WFREST_HTTPKEEPALIVEUTIL_H_

--- a/src/core/HttpServerTask.cc
+++ b/src/core/HttpServerTask.cc
@@ -6,12 +6,9 @@
 #include "HttpServerTask.h"
 #include "HttpServer.h"
 #include "HttpHeaderUtil.h"
-#include "StrUtil.h"
+#include "HttpKeepAliveUtil.h"
 
 using namespace protocol;
-
-#define HTTP_KEEPALIVE_DEFAULT    (60 * 1000)
-#define HTTP_KEEPALIVE_MAX        (300 * 1000)
 
 
 namespace wfrest
@@ -133,48 +130,12 @@ CommMessageOut *HttpServerTask::message_out()
         this->keep_alive_timeo = 0;
     else
     {
-        //req---Connection: Keep-Alive
-        //req---Keep-Alive: timeout=5,max=100
-
-        if (req_has_keep_alive_header_)
-        {
-            int flag = 0;
-            std::vector<std::string> params = StrUtil::split(req_keep_alive_, ',');
-
-            for (const auto &kv: params)
-            {
-                std::vector<std::string> arr = StrUtil::split(kv, '=');
-                if (arr.size() < 2)
-                    arr.emplace_back("0");
-
-                std::string key = StrUtil::strip(arr[0]);
-                std::string val = StrUtil::strip(arr[1]);
-                if (!(flag & 1) && strcasecmp(key.c_str(), "timeout") == 0)
-                {
-                    flag |= 1;
-                    // keep_alive_timeo = 5000ms when Keep-Alive: timeout=5
-                    this->keep_alive_timeo = 1000 * atoi(val.c_str());
-                    if (flag == 3)
-                        break;
-                } else if (!(flag & 2) && strcasecmp(key.c_str(), "max") == 0)
-                {
-                    flag |= 2;
-                    if (this->get_seq() >= atoi(val.c_str()))
-                    {
-                        this->keep_alive_timeo = 0;
-                        break;
-                    }
-
-                    if (flag == 3)
-                        break;
-                }
-            }
-        }
-
-        if ((unsigned int) this->keep_alive_timeo > HTTP_KEEPALIVE_MAX)
-            this->keep_alive_timeo = HTTP_KEEPALIVE_MAX;
-        //if (this->keep_alive_timeo < 0 || this->keep_alive_timeo > HTTP_KEEPALIVE_MAX)
-
+        static const std::string empty_keep_alive;
+        const std::string &keep_alive = req_has_keep_alive_header_
+                                            ? req_keep_alive_
+                                            : empty_keep_alive;
+        this->keep_alive_timeo = detail::resolve_keep_alive_timeout(
+            keep_alive, this->get_seq(), this->keep_alive_timeo);
     }
 
     if (!resp->has_connection_header())

--- a/test/HttpHeaderUtil_unittest.cc
+++ b/test/HttpHeaderUtil_unittest.cc
@@ -1,12 +1,14 @@
 #include <gtest/gtest.h>
 
 #include <map>
+#include <limits>
 #include <string>
 #include <vector>
 
 #include "wfrest/HttpMsg.h"
 #include "workflow/HttpUtil.h"
 #include "../src/core/HttpHeaderUtil.h"
+#include "../src/core/HttpKeepAliveUtil.h"
 
 using namespace wfrest;
 
@@ -90,4 +92,112 @@ TEST(HttpHeaderUtil, response_wrappers_reject_unsafe_and_framing_fields)
     EXPECT_EQ(parsed.get("X-Low"), "updated");
     EXPECT_TRUE(parsed.get("X-Bad").empty());
     EXPECT_TRUE(parsed.get("Transfer-Encoding").empty());
+}
+
+TEST(HttpKeepAliveUtil, accepts_only_complete_unsigned_decimal_values)
+{
+    using detail::resolve_keep_alive_timeout;
+    const int configured = 60000;
+
+    EXPECT_EQ(resolve_keep_alive_timeout("timeout=5", 0, configured), 5000);
+    EXPECT_EQ(resolve_keep_alive_timeout(
+                  " extension=value, \tTiMeOuT \t= \t5 \t", 0, configured),
+              5000);
+    EXPECT_EQ(resolve_keep_alive_timeout(
+                  "timeout=bad, timeout=7", 0, configured),
+              7000);
+    EXPECT_EQ(resolve_keep_alive_timeout(
+                  "timeout=5, timeout=1", 0, configured),
+              5000);
+
+    const std::vector<std::string> malformed = {
+        "timeout=", "timeout=-1", "timeout=+1", "timeout=1.5",
+        "timeout=5junk", "timeout=5=6", "timeout=1 0"
+    };
+    for (const std::string &header : malformed)
+    {
+        EXPECT_EQ(resolve_keep_alive_timeout(header, 0, configured),
+                  configured) << header;
+    }
+
+    std::string with_nul = "timeout=5";
+    with_nul.push_back('\0');
+    with_nul += "junk";
+    EXPECT_EQ(resolve_keep_alive_timeout(with_nul, 0, configured),
+              configured);
+
+    const std::string huge(10000, '9');
+    EXPECT_EQ(resolve_keep_alive_timeout(
+                  "timeout=" + huge, 0, 300000),
+              300000);
+    EXPECT_EQ(resolve_keep_alive_timeout(
+                  "timeout=" + huge + "x", 0, configured),
+              configured);
+}
+
+TEST(HttpKeepAliveUtil, request_timeout_never_extends_server_policy)
+{
+    using detail::resolve_keep_alive_timeout;
+
+    EXPECT_EQ(resolve_keep_alive_timeout("", 0, 0), 0);
+    EXPECT_EQ(resolve_keep_alive_timeout("", 0, 5000), 5000);
+    EXPECT_EQ(resolve_keep_alive_timeout("", 0, -1), 300000);
+    EXPECT_EQ(resolve_keep_alive_timeout("", 0, 300001), 300000);
+
+    EXPECT_EQ(resolve_keep_alive_timeout("timeout=0", 0, 60000), 0);
+    EXPECT_EQ(resolve_keep_alive_timeout("timeout=5", 0, 60000), 5000);
+    EXPECT_EQ(resolve_keep_alive_timeout("timeout=60", 0, 60000), 60000);
+    EXPECT_EQ(resolve_keep_alive_timeout("timeout=300", 0, 5000), 5000);
+    EXPECT_EQ(resolve_keep_alive_timeout("timeout=999999", 0, 5000),
+              5000);
+    EXPECT_EQ(resolve_keep_alive_timeout("timeout=-1", 0, 5000), 5000);
+}
+
+TEST(HttpKeepAliveUtil, max_uses_one_based_request_ordinal)
+{
+    using detail::resolve_keep_alive_timeout;
+    const int configured = 60000;
+
+    EXPECT_EQ(resolve_keep_alive_timeout("max=0", 0, configured), 0);
+    EXPECT_EQ(resolve_keep_alive_timeout("max=1", 0, configured), 0);
+    EXPECT_EQ(resolve_keep_alive_timeout("max=2", 0, configured),
+              configured);
+    EXPECT_EQ(resolve_keep_alive_timeout("max=5", 4, configured), 0);
+    EXPECT_EQ(resolve_keep_alive_timeout("max=6", 4, configured),
+              configured);
+    EXPECT_EQ(resolve_keep_alive_timeout("max=1", -1, configured), 0);
+    EXPECT_EQ(resolve_keep_alive_timeout("max=2", -1, configured),
+              configured);
+
+    EXPECT_EQ(resolve_keep_alive_timeout(
+                  "max=bad, max=2", 0, configured),
+              configured);
+    EXPECT_EQ(resolve_keep_alive_timeout(
+                  "max=2, max=1", 0, configured),
+              configured);
+    EXPECT_EQ(resolve_keep_alive_timeout(
+                  "max=18446744073709551615",
+                  std::numeric_limits<long long>::max(),
+                  configured),
+              configured);
+    EXPECT_EQ(resolve_keep_alive_timeout(
+                  "max=9223372036854775808",
+                  std::numeric_limits<long long>::max(),
+                  configured),
+              0);
+}
+
+TEST(HttpKeepAliveUtil, combines_timeout_and_max_independently)
+{
+    using detail::resolve_keep_alive_timeout;
+
+    EXPECT_EQ(resolve_keep_alive_timeout(
+                  "timeout=5, max=2", 0, 60000),
+              5000);
+    EXPECT_EQ(resolve_keep_alive_timeout(
+                  "max=1, timeout=5", 0, 60000),
+              0);
+    EXPECT_EQ(resolve_keep_alive_timeout(
+                  "unknown, max=bad, timeout=bad", 0, 60000),
+              60000);
 }

--- a/test/HttpServer/header_test.cc
+++ b/test/HttpServer/header_test.cc
@@ -80,7 +80,7 @@ TEST(HttpServer, validates_response_headers_and_framing)
 {
     ScopedTimezone timezone("EST5");
     HttpServer server;
-    WFFacilities::WaitGroup wait_group(5);
+    WFFacilities::WaitGroup wait_group(7);
 
     server.GET("/sanitize", [](const HttpReq *, HttpResp *resp)
     {
@@ -181,6 +181,35 @@ TEST(HttpServer, validates_response_headers_and_framing)
         wait_group.done();
     });
     problem->start();
+
+    WFHttpTask *keep_alive_max = ClientUtil::create_http_task("sanitize");
+    EXPECT_TRUE(keep_alive_max->get_req()->add_header_pair(
+        "Connection", "Keep-Alive"));
+    EXPECT_TRUE(keep_alive_max->get_req()->add_header_pair(
+        "Keep-Alive", "max=1"));
+    keep_alive_max->set_callback([&](WFHttpTask *task)
+    {
+        EXPECT_EQ(task->get_state(), WFT_STATE_SUCCESS);
+        HttpHeaderMap headers(task->get_resp());
+        EXPECT_EQ(headers.get("Connection"), "close");
+        wait_group.done();
+    });
+    keep_alive_max->start();
+
+    WFHttpTask *keep_alive_malformed =
+        ClientUtil::create_http_task("sanitize");
+    EXPECT_TRUE(keep_alive_malformed->get_req()->add_header_pair(
+        "Connection", "Keep-Alive"));
+    EXPECT_TRUE(keep_alive_malformed->get_req()->add_header_pair(
+        "Keep-Alive", "timeout=garbage"));
+    keep_alive_malformed->set_callback([&](WFHttpTask *task)
+    {
+        EXPECT_EQ(task->get_state(), WFT_STATE_SUCCESS);
+        HttpHeaderMap headers(task->get_resp());
+        EXPECT_EQ(headers.get("Connection"), "Keep-Alive");
+        wait_group.done();
+    });
+    keep_alive_malformed->start();
 
     wait_group.wait();
     server.stop();


### PR DESCRIPTION
Closes #361

## Why

Client-controlled `Keep-Alive` parameters were parsed with `atoi()` and signed millisecond multiplication. This produced UBSan overflow, converted negative values into the five-minute maximum, treated malformed text as zero, allowed clients to raise server timeouts, and applied `max` one response late.

## Plan

- add an internal allocation-free policy resolver with ASCII-only keys/OWS;
- validate complete unsigned decimals and saturate while still scanning all bytes;
- normalize the existing 300-second hard ceiling explicitly;
- apply valid request timeout only as `min(server, client)`;
- let the first valid duplicate win while malformed values remain ignorable;
- compare `max` with a safe one-based request ordinal;
- wire the server response path to the resolver;
- add numeric/grammar/policy unit tests and live server/client assertions.

## Compatibility

No public API changes. Valid decimal hints and unknown extensions remain supported. Malformed values are ignored rather than becoming zero, negative/trailing-junk values no longer alter policy, client hints cannot extend server configuration, and `max=1` closes after the first response.

## Validation

- original unsafe expression reproduced under UBSan;
- fixed UBSan probe output: `5000,60000,60000,0,60000,1000`;
- policy unit tests: 8/8 passed;
- live server/client integration: 1/1 passed;
- strict C++11 production and C++14 test `-Werror` compilation;
- ASan + UBSan: policy 8/8 and server integration 1/1 passed;
- full CTest suite: 37/37 passed;
- cached `git diff --check`.

Spec: #362