### PR TITLE
fix(sysinfo): refresh thread cache after fork

### DIFF
--- a/src/base/SysInfo.cc
+++ b/src/base/SysInfo.cc
@@ -1,4 +1,5 @@
 #include <type_traits>
+#include <pthread.h>
 #include "SysInfo.h"
 
 namespace wfrest
@@ -8,8 +9,37 @@ namespace CurrentThread
 {
 thread_local int t_cached_tid = 0;
 thread_local char t_tid_str[32];
-thread_local int t_tid_str_len = 6;
+thread_local int t_tid_str_len = 0;
 static_assert(std::is_same<int, pid_t>::value, "pid_t should be int");
+
+namespace
+{
+
+pthread_once_t atfork_once = PTHREAD_ONCE_INIT;
+
+void reset_tid_cache_after_fork()
+{
+    t_cached_tid = 0;
+    t_tid_str[0] = '\0';
+    t_tid_str_len = 0;
+}
+
+void install_tid_cache_atfork()
+{
+    (void)pthread_atfork(nullptr, nullptr, reset_tid_cache_after_fork);
+}
+
+} // namespace
+
+namespace detail
+{
+
+void register_tid_cache_atfork()
+{
+    (void)pthread_once(&atfork_once, install_tid_cache_atfork);
+}
+
+} // namespace detail
 
 }  // namespace CurrentThread
 }  // namespace wfrest

--- a/src/base/SysInfo.h
+++ b/src/base/SysInfo.h
@@ -16,12 +16,18 @@ extern thread_local int t_cached_tid;
 extern thread_local char t_tid_str[32];
 extern thread_local int t_tid_str_len;
 
+namespace detail
+{
+void register_tid_cache_atfork();
+}
+
 inline pid_t gettid() { return static_cast<pid_t>(::syscall(SYS_gettid)); }
 
 inline void cacheTid()
 {
     if (t_cached_tid == 0)
     {
+        detail::register_tid_cache_atfork();
         t_cached_tid = gettid();
         t_tid_str_len = snprintf(t_tid_str, sizeof t_tid_str, "%5d ", t_cached_tid);
     }
@@ -37,9 +43,17 @@ inline int tid()
 }
 
 // for logging
-inline const char *tid_str() { return t_tid_str; }
+inline const char *tid_str()
+{
+    cacheTid();
+    return t_tid_str;
+}
 // for logging
-inline int tid_str_len() { return t_tid_str_len; }
+inline int tid_str_len()
+{
+    cacheTid();
+    return t_tid_str_len;
+}
 
 }  // namespace CurrentThread
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,6 +56,7 @@ set(WFREST_LIB wfrest workflow pthread OpenSSL::SSL OpenSSL::Crypto z)
 
 set(UNIT_TEST_LIST
 	TimeStamp_unittest
+	SysInfo_unittest
 	StrUtil_unittest
 	StringPiece_unittest
 	Json_unittest

--- a/test/SysInfo_unittest.cc
+++ b/test/SysInfo_unittest.cc
@@ -1,0 +1,72 @@
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "wfrest/SysInfo.h"
+
+using namespace wfrest;
+
+TEST(SysInfo, text_access_initializes_coherent_cache)
+{
+    const int length = CurrentThread::tid_str_len();
+    const char *text = CurrentThread::tid_str();
+
+    EXPECT_GT(length, 0);
+    EXPECT_EQ(static_cast<size_t>(length), std::strlen(text));
+    EXPECT_EQ(std::atoi(text), CurrentThread::tid());
+    EXPECT_EQ(text[length - 1], ' ');
+    EXPECT_EQ(CurrentThread::tid(), CurrentThread::gettid());
+}
+
+TEST(SysInfo, cache_is_initialized_independently_in_worker_thread)
+{
+    const int main_tid = CurrentThread::tid();
+    int worker_tid = 0;
+    int worker_actual = 0;
+    int worker_length = 0;
+    size_t worker_text_size = 0;
+
+    std::thread worker([&]
+    {
+        worker_length = CurrentThread::tid_str_len();
+        worker_text_size = std::strlen(CurrentThread::tid_str());
+        worker_tid = CurrentThread::tid();
+        worker_actual = CurrentThread::gettid();
+    });
+    worker.join();
+
+    EXPECT_NE(worker_tid, main_tid);
+    EXPECT_EQ(worker_tid, worker_actual);
+    EXPECT_EQ(static_cast<size_t>(worker_length), worker_text_size);
+    EXPECT_EQ(CurrentThread::tid(), main_tid);
+}
+
+TEST(SysInfo, child_refreshes_inherited_cache_after_fork)
+{
+    const int parent_tid = CurrentThread::tid();
+    const pid_t child = fork();
+    ASSERT_GE(child, 0);
+
+    if (child == 0)
+    {
+        const int child_tid = CurrentThread::tid();
+        const int child_actual = CurrentThread::gettid();
+        const int length = CurrentThread::tid_str_len();
+        const bool valid = child_tid == child_actual &&
+                           child_tid != parent_tid &&
+                           static_cast<size_t>(length) ==
+                               std::strlen(CurrentThread::tid_str()) &&
+                           std::atoi(CurrentThread::tid_str()) == child_tid;
+        _exit(valid ? 0 : 1);
+    }
+
+    int status = 0;
+    ASSERT_EQ(waitpid(child, &status, 0), child);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+    EXPECT_EQ(CurrentThread::tid(), parent_tid);
+}


### PR DESCRIPTION
Closes #364

## Why

The thread-text accessors returned an uninitialized empty buffer with a hard-coded length of 6 unless `tid()` happened to run first. After `fork()`, the child inherited a nonzero parent TID and never refreshed it.

## Plan

- initialize text length to zero;
- route all public accessors through `cacheTid()`;
- install one `pthread_atfork` child callback via `pthread_once`;
- reset only TLS scalar/buffer state in the child;
- lazily format the child TID on its next access;
- add a registered three-case SysInfo test covering fresh access, worker TLS, and fork.

## Compatibility

Signatures and `%5d ` formatting are unchanged. Direct text access becomes self-initializing and children report their own TID.

## Validation

- fresh probe: reported/string lengths changed from `6/0` to matching `8/8` in this environment;
- fork probe: child mismatch exit changed from 1 to 0;
- strict C++11 production and C++14 test `-Werror` compilation;
- focused ASan + UBSan: 3/3 passed with leak detection;
- full CTest suite: 38/38 passed;
- cached `git diff --check`.

Spec: #365