### PR TITLE
fix(server): validate peer metadata lookups

### DIFF
--- a/src/core/HttpServerTask.cc
+++ b/src/core/HttpServerTask.cc
@@ -159,43 +159,56 @@ CommMessageOut *HttpServerTask::message_out()
 
 std::string HttpServerTask::peer_addr() const
 {
-    struct sockaddr_storage addr;
+    struct sockaddr_storage addr{};
     socklen_t addr_len = sizeof addr;
-    this->get_peer_addr(reinterpret_cast<struct sockaddr *>(&addr), &addr_len);
+    if (this->get_peer_addr(reinterpret_cast<struct sockaddr *>(&addr),
+                            &addr_len) != 0)
+        return "Unknown";
 
-    static const int ADDR_STR_LEN = 128;
-    char addrstr[ADDR_STR_LEN];
-    if (addr.ss_family == AF_INET)
+    const void *binary_addr = nullptr;
+    int family = addr.ss_family;
+    if (family == AF_INET && addr_len >= sizeof(struct sockaddr_in))
     {
-        auto *sin = reinterpret_cast<struct sockaddr_in *>(&addr);
-        inet_ntop(AF_INET, &sin->sin_addr, addrstr, ADDR_STR_LEN);
-    } else if (addr.ss_family == AF_INET6)
+        const auto *sin = reinterpret_cast<const struct sockaddr_in *>(&addr);
+        binary_addr = &sin->sin_addr;
+    } else if (family == AF_INET6 &&
+               addr_len >= sizeof(struct sockaddr_in6))
     {
-        auto *sin6 = reinterpret_cast<struct sockaddr_in6 *>(&addr);
-        inet_ntop(AF_INET6, &sin6->sin6_addr, addrstr, ADDR_STR_LEN);
+        const auto *sin6 =
+            reinterpret_cast<const struct sockaddr_in6 *>(&addr);
+        binary_addr = &sin6->sin6_addr;
     } else
-        strcpy(addrstr, "Unknown");
+        return "Unknown";
 
+    char addrstr[INET6_ADDRSTRLEN];
+    if (inet_ntop(family, binary_addr, addrstr, sizeof addrstr) == nullptr)
+        return "Unknown";
     return addrstr;
 }
 
 unsigned short HttpServerTask::peer_port() const
 {
-    struct sockaddr_storage addr;
+    struct sockaddr_storage addr{};
     socklen_t addr_len = sizeof addr;
-    this->get_peer_addr(reinterpret_cast<struct sockaddr *>(&addr), &addr_len);
+    if (this->get_peer_addr(reinterpret_cast<struct sockaddr *>(&addr),
+                            &addr_len) != 0)
+        return 0;
 
-    unsigned short port = 0;
-    if (addr.ss_family == AF_INET)
+    if (addr.ss_family == AF_INET &&
+        addr_len >= sizeof(struct sockaddr_in))
     {
-        auto *sin = reinterpret_cast<struct sockaddr_in *>(&addr);
-        port = ntohs(sin->sin_port);
+        const auto *sin = reinterpret_cast<const struct sockaddr_in *>(&addr);
+        return ntohs(sin->sin_port);
     } else if (addr.ss_family == AF_INET6)
     {
-        auto *sin6 = reinterpret_cast<struct sockaddr_in6 *>(&addr);
-        port = ntohs(sin6->sin6_port);
+        if (addr_len >= sizeof(struct sockaddr_in6))
+        {
+            const auto *sin6 =
+                reinterpret_cast<const struct sockaddr_in6 *>(&addr);
+            return ntohs(sin6->sin6_port);
+        }
     }
-    return port;
+    return 0;
 }
 
 

--- a/test/HttpMsg_unittest.cc
+++ b/test/HttpMsg_unittest.cc
@@ -1,9 +1,12 @@
+#include <arpa/inet.h>
+#include <cerrno>
 #include <cstdint>
 #include <cstring>
 #include <new>
 #include <string>
 #include <gtest/gtest.h>
 #include "wfrest/HttpMsg.h"
+#include "wfrest/HttpServerTask.h"
 
 using namespace wfrest;
 
@@ -17,7 +20,116 @@ std::string output_body(const protocol::HttpMessage &message)
     return body;
 }
 
+class PeerTestTask : public HttpServerTask
+{
+public:
+    explicit PeerTestTask(ProcFunc& process) :
+        HttpServerTask(nullptr, process)
+    {}
+
+    ~PeerTestTask()
+    {
+        this->target = nullptr;
+    }
+
+    void use_peer(CommTarget *peer)
+    {
+        this->target = peer;
+    }
+};
+
+class ScopedCommTarget
+{
+public:
+    ScopedCommTarget(const struct sockaddr *addr, socklen_t addr_len) :
+        initialized_(target_.init(addr, addr_len, 0, 0) == 0)
+    {}
+
+    ~ScopedCommTarget()
+    {
+        if (initialized_)
+            target_.deinit();
+    }
+
+    bool initialized() const
+    {
+        return initialized_;
+    }
+
+    CommTarget *get()
+    {
+        return &target_;
+    }
+
+private:
+    ScopedCommTarget(const ScopedCommTarget&) = delete;
+    ScopedCommTarget& operator=(const ScopedCommTarget&) = delete;
+
+    CommTarget target_;
+    bool initialized_;
+};
+
 } // namespace
+
+TEST(HttpServerTaskPeer, rejects_unavailable_or_truncated_addresses)
+{
+    struct sockaddr truncated{};
+    truncated.sa_family = AF_INET;
+    ScopedCommTarget short_target(
+        &truncated, sizeof(truncated.sa_family));
+    ASSERT_TRUE(short_target.initialized());
+
+    HttpServerTask::ProcFunc process = [](HttpTask *) {};
+    PeerTestTask task(process);
+
+    struct sockaddr_storage untouched;
+    std::memset(&untouched, 0xA5, sizeof untouched);
+    struct sockaddr_storage expected = untouched;
+    socklen_t untouched_len = sizeof untouched;
+    errno = 0;
+    EXPECT_EQ(task.get_peer_addr(
+        reinterpret_cast<struct sockaddr *>(&untouched), &untouched_len), -1);
+    EXPECT_EQ(errno, ENOTCONN);
+    EXPECT_EQ(untouched_len, sizeof untouched);
+    EXPECT_EQ(std::memcmp(&untouched, &expected, sizeof untouched), 0);
+
+    EXPECT_EQ(task.peer_addr(), "Unknown");
+    EXPECT_EQ(task.peer_port(), 0);
+
+    task.use_peer(short_target.get());
+    EXPECT_EQ(task.peer_addr(), "Unknown");
+    EXPECT_EQ(task.peer_port(), 0);
+}
+
+TEST(HttpServerTaskPeer, formats_ipv4_and_ipv6_addresses)
+{
+    struct sockaddr_in ipv4{};
+    ipv4.sin_family = AF_INET;
+    ipv4.sin_port = htons(8080);
+    ASSERT_EQ(inet_pton(AF_INET, "127.0.0.1", &ipv4.sin_addr), 1);
+    ScopedCommTarget ipv4_target(
+        reinterpret_cast<const struct sockaddr *>(&ipv4), sizeof ipv4);
+    ASSERT_TRUE(ipv4_target.initialized());
+
+    struct sockaddr_in6 ipv6{};
+    ipv6.sin6_family = AF_INET6;
+    ipv6.sin6_port = htons(8443);
+    ASSERT_EQ(inet_pton(AF_INET6, "::1", &ipv6.sin6_addr), 1);
+    ScopedCommTarget ipv6_target(
+        reinterpret_cast<const struct sockaddr *>(&ipv6), sizeof ipv6);
+    ASSERT_TRUE(ipv6_target.initialized());
+
+    HttpServerTask::ProcFunc process = [](HttpTask *) {};
+    PeerTestTask task(process);
+
+    task.use_peer(ipv4_target.get());
+    EXPECT_EQ(task.peer_addr(), "127.0.0.1");
+    EXPECT_EQ(task.peer_port(), 8080);
+
+    task.use_peer(ipv6_target.get());
+    EXPECT_EQ(task.peer_addr(), "::1");
+    EXPECT_EQ(task.peer_port(), 8443);
+}
 
 TEST(HttpReqMove, initializes_default_and_wrapped_requests)
 {


### PR DESCRIPTION
Closes #367

## Why

`peer_addr()` and `peer_port()` read `sockaddr_storage` even when Workflow returns `-1/ENOTCONN` without writing it. A short family-tagged address also made the wrappers read beyond the producer-declared length, while `peer_addr()` trusted `inet_ntop()` output without checking success.

## Plan

- value-initialize local address storage as defense in depth;
- stop immediately when peer lookup fails;
- require full IPv4/IPv6 structure lengths before casting and reading;
- check `inet_ntop()` before constructing the returned string;
- preserve successful IPv4/IPv6 address and port results;
- cover disconnected, truncated, IPv4, and IPv6 cases.

## Compatibility

Public signatures and successful connected output are unchanged. Unavailable, unsupported, truncated, and failed-conversion paths now deterministically return `"Unknown"` or zero.

## Validation

- deterministic lookup probe: `-1/ENOTCONN`, unchanged 128-byte output and length;
- old implementation against the new regression: failed with a truncated address misread as `162.88.0.0:32818`;
- new focused peer tests: 2/2 passed;
- complete `HttpMsg_unittest`: 9/9 passed;
- strict C++11 production and C++14 test compilation with `-Werror`;
- focused ASan + UBSan with leak detection: 9/9 passed;
- full CTest suite: 38/38 passed;
- cached `git diff --check`.

Spec: #368
