### PR TITLE
fix(http): sanitize response start lines

### DIFF
--- a/src/core/HttpServerTask.cc
+++ b/src/core/HttpServerTask.cc
@@ -2,6 +2,8 @@
 #include "workflow/HttpMessage.h"
 
 #include <arpa/inet.h>
+#include <cstdio>
+#include <cstring>
 
 #include "HttpServerTask.h"
 #include "HttpServer.h"
@@ -13,6 +15,79 @@ using namespace protocol;
 
 namespace wfrest
 {
+
+namespace
+{
+
+bool is_supported_http_version(const char *version)
+{
+    return version != nullptr &&
+           (std::strcmp(version, "HTTP/1.0") == 0 ||
+            std::strcmp(version, "HTTP/1.1") == 0);
+}
+
+bool parse_status_code(const char *text, int *status_code)
+{
+    if (text == nullptr)
+        return false;
+
+    int value = 0;
+    for (size_t i = 0; i < 3; ++i)
+    {
+        const unsigned char ch = static_cast<unsigned char>(text[i]);
+        if (ch < '0' || ch > '9')
+            return false;
+        value = value * 10 + (ch - '0');
+    }
+
+    if (text[3] != '\0' || value < 100)
+        return false;
+
+    *status_code = value;
+    return true;
+}
+
+bool is_valid_reason_phrase(const char *phrase)
+{
+    if (phrase == nullptr)
+        return false;
+
+    const auto *cursor = reinterpret_cast<const unsigned char *>(phrase);
+    while (*cursor != '\0')
+    {
+        const unsigned char ch = *cursor++;
+        const bool valid = ch == '\t' || ch == ' ' ||
+                           (ch >= 0x21 && ch <= 0x7e) || ch >= 0x80;
+        if (!valid)
+            return false;
+    }
+    return true;
+}
+
+void sanitize_response_start_line(HttpResp *resp)
+{
+    if (!is_supported_http_version(resp->get_http_version()))
+        resp->set_http_version("HTTP/1.1");
+
+    const char *status_text = resp->get_status_code();
+    if (status_text == nullptr)
+    {
+        HttpUtil::set_response_status(resp, HttpStatusOK);
+        return;
+    }
+
+    int status_code;
+    if (!parse_status_code(status_text, &status_code))
+    {
+        HttpUtil::set_response_status(resp, HttpStatusInternalServerError);
+        return;
+    }
+
+    if (!is_valid_reason_phrase(resp->get_reason_phrase()))
+        HttpUtil::set_response_status(resp, status_code);
+}
+
+} // namespace
 
 HttpServerTask::HttpServerTask(CommService *service,
                                ProcFunc& process) :
@@ -55,6 +130,7 @@ void HttpServerTask::handle(int state, int error)
 CommMessageOut *HttpServerTask::message_out()
 {
     HttpResp *resp = this->get_resp();
+    sanitize_response_start_line(resp);
 
     std::map<std::string, std::string, MapStringCaseLess> &headers = resp->headers;
     detail::sanitize_application_response_headers(&headers);
@@ -93,22 +169,6 @@ CommMessageOut *HttpServerTask::message_out()
         resp->protocol::HttpResponse::add_header(&header);
     }
 
-    if (!resp->get_http_version())
-        resp->set_http_version("HTTP/1.1");
-
-    const char *status_code_str = resp->get_status_code();
-    if (!status_code_str || !resp->get_reason_phrase())
-    {
-        int status_code;
-
-        if (status_code_str)
-            status_code = atoi(status_code_str);
-        else
-            status_code = HttpStatusOK;
-
-        HttpUtil::set_response_status(resp, status_code);
-    }
-    
     if (!resp->is_chunked() && !resp->has_content_length_header())
     {
         char buf[32];

--- a/test/HttpMsg_unittest.cc
+++ b/test/HttpMsg_unittest.cc
@@ -20,14 +20,14 @@ std::string output_body(const protocol::HttpMessage &message)
     return body;
 }
 
-class PeerTestTask : public HttpServerTask
+class ServerTaskHarness : public HttpServerTask
 {
 public:
-    explicit PeerTestTask(ProcFunc& process) :
+    explicit ServerTaskHarness(ProcFunc& process) :
         HttpServerTask(nullptr, process)
     {}
 
-    ~PeerTestTask()
+    ~ServerTaskHarness()
     {
         this->target = nullptr;
     }
@@ -35,6 +35,11 @@ public:
     void use_peer(CommTarget *peer)
     {
         this->target = peer;
+    }
+
+    CommMessageOut *finalize_response()
+    {
+        return this->message_out();
     }
 };
 
@@ -80,7 +85,7 @@ TEST(HttpServerTaskPeer, rejects_unavailable_or_truncated_addresses)
     ASSERT_TRUE(short_target.initialized());
 
     HttpServerTask::ProcFunc process = [](HttpTask *) {};
-    PeerTestTask task(process);
+    ServerTaskHarness task(process);
 
     struct sockaddr_storage untouched;
     std::memset(&untouched, 0xA5, sizeof untouched);
@@ -120,7 +125,7 @@ TEST(HttpServerTaskPeer, formats_ipv4_and_ipv6_addresses)
     ASSERT_TRUE(ipv6_target.initialized());
 
     HttpServerTask::ProcFunc process = [](HttpTask *) {};
-    PeerTestTask task(process);
+    ServerTaskHarness task(process);
 
     task.use_peer(ipv4_target.get());
     EXPECT_EQ(task.peer_addr(), "127.0.0.1");
@@ -129,6 +134,76 @@ TEST(HttpServerTaskPeer, formats_ipv4_and_ipv6_addresses)
     task.use_peer(ipv6_target.get());
     EXPECT_EQ(task.peer_addr(), "::1");
     EXPECT_EQ(task.peer_port(), 8443);
+}
+
+TEST(HttpServerTaskStartLine, defaults_and_preserves_safe_custom_fields)
+{
+    HttpServerTask::ProcFunc process = [](HttpTask *) {};
+
+    ServerTaskHarness defaults(process);
+    ASSERT_NE(defaults.finalize_response(), nullptr);
+    EXPECT_STREQ(defaults.get_resp()->get_http_version(), "HTTP/1.1");
+    EXPECT_STREQ(defaults.get_resp()->get_status_code(), "200");
+    EXPECT_STREQ(defaults.get_resp()->get_reason_phrase(), "OK");
+
+    ServerTaskHarness custom(process);
+    std::string custom_phrase = "Custom\tStatus ";
+    custom_phrase.push_back(static_cast<char>(0x80));
+    ASSERT_TRUE(custom.get_resp()->set_http_version("HTTP/1.0"));
+    ASSERT_TRUE(custom.get_resp()->set_status_code("799"));
+    ASSERT_TRUE(custom.get_resp()->set_reason_phrase(custom_phrase));
+    ASSERT_NE(custom.finalize_response(), nullptr);
+    EXPECT_STREQ(custom.get_resp()->get_http_version(), "HTTP/1.0");
+    EXPECT_STREQ(custom.get_resp()->get_status_code(), "799");
+    EXPECT_EQ(std::string(custom.get_resp()->get_reason_phrase()),
+              custom_phrase);
+
+    ServerTaskHarness empty_phrase(process);
+    ASSERT_TRUE(empty_phrase.get_resp()->set_status_code("299"));
+    ASSERT_TRUE(empty_phrase.get_resp()->set_reason_phrase(""));
+    ASSERT_NE(empty_phrase.finalize_response(), nullptr);
+    EXPECT_STREQ(empty_phrase.get_resp()->get_status_code(), "299");
+    EXPECT_STREQ(empty_phrase.get_resp()->get_reason_phrase(), "");
+}
+
+TEST(HttpServerTaskStartLine, normalizes_invalid_start_line_fields)
+{
+    HttpServerTask::ProcFunc process = [](HttpTask *) {};
+
+    ServerTaskHarness injected(process);
+    ASSERT_TRUE(injected.get_resp()->set_http_version(
+        "HTTP/1.1\r\nX-Version: injected"));
+    ASSERT_TRUE(injected.get_resp()->set_status_code("299"));
+    ASSERT_TRUE(injected.get_resp()->set_reason_phrase(
+        "Custom\r\nX-Reason: injected"));
+    ASSERT_NE(injected.finalize_response(), nullptr);
+    EXPECT_STREQ(injected.get_resp()->get_http_version(), "HTTP/1.1");
+    EXPECT_STREQ(injected.get_resp()->get_status_code(), "299");
+    EXPECT_STREQ(injected.get_resp()->get_reason_phrase(), "Unknown");
+
+    ServerTaskHarness control(process);
+    ASSERT_TRUE(control.get_resp()->set_status_code("299"));
+    ASSERT_TRUE(control.get_resp()->set_reason_phrase("Custom\x7f"));
+    ASSERT_NE(control.finalize_response(), nullptr);
+    EXPECT_STREQ(control.get_resp()->get_status_code(), "299");
+    EXPECT_STREQ(control.get_resp()->get_reason_phrase(), "Unknown");
+
+    const char *invalid_codes[] = {
+        "99", "099", "+200", "200x", "200\r\nX-Code: injected",
+        "999999999999999999999999"
+    };
+    for (const char *invalid_code : invalid_codes)
+    {
+        ServerTaskHarness invalid(process);
+        ASSERT_TRUE(invalid.get_resp()->set_http_version("HTTP/2.0"));
+        ASSERT_TRUE(invalid.get_resp()->set_status_code(invalid_code));
+        ASSERT_TRUE(invalid.get_resp()->set_reason_phrase("Custom"));
+        ASSERT_NE(invalid.finalize_response(), nullptr);
+        EXPECT_STREQ(invalid.get_resp()->get_http_version(), "HTTP/1.1");
+        EXPECT_STREQ(invalid.get_resp()->get_status_code(), "500");
+        EXPECT_STREQ(invalid.get_resp()->get_reason_phrase(),
+                     "Internal Server Error");
+    }
 }
 
 TEST(HttpReqMove, initializes_default_and_wrapped_requests)

--- a/test/HttpServer/header_test.cc
+++ b/test/HttpServer/header_test.cc
@@ -80,7 +80,7 @@ TEST(HttpServer, validates_response_headers_and_framing)
 {
     ScopedTimezone timezone("EST5");
     HttpServer server;
-    WFFacilities::WaitGroup wait_group(7);
+    WFFacilities::WaitGroup wait_group(8);
 
     server.GET("/sanitize", [](const HttpReq *, HttpResp *resp)
     {
@@ -116,6 +116,12 @@ TEST(HttpServer, validates_response_headers_and_framing)
         Json value;
         value["problem"] = true;
         resp->Json(value);
+    });
+    server.GET("/start-line", [](const HttpReq *, HttpResp *resp)
+    {
+        resp->set_status_code("299");
+        resp->set_reason_phrase("Custom\r\nX-Start-Line-Injected: yes");
+        resp->String("safe");
     });
     ASSERT_EQ(server.start("127.0.0.1", 8888), 0);
 
@@ -181,6 +187,19 @@ TEST(HttpServer, validates_response_headers_and_framing)
         wait_group.done();
     });
     problem->start();
+
+    WFHttpTask *start_line = ClientUtil::create_http_task("start-line");
+    start_line->set_callback([&](WFHttpTask *task)
+    {
+        EXPECT_EQ(task->get_state(), WFT_STATE_SUCCESS);
+        EXPECT_STREQ(task->get_resp()->get_status_code(), "299");
+        EXPECT_STREQ(task->get_resp()->get_reason_phrase(), "Unknown");
+        HttpHeaderMap headers(task->get_resp());
+        EXPECT_TRUE(headers.get("X-Start-Line-Injected").empty());
+        EXPECT_EQ(response_body(task), "safe");
+        wait_group.done();
+    });
+    start_line->start();
 
     WFHttpTask *keep_alive_max = ClientUtil::create_http_task("sanitize");
     EXPECT_TRUE(keep_alive_max->get_req()->add_header_pair(


### PR DESCRIPTION
Closes #370

## Why

Workflow's raw response setters accept arbitrary strings and its encoder writes them directly as the HTTP start line. WFRest previously trusted present values, so CRLF in a reason phrase became a forged response header on a real socket. The missing-reason path also used `atoi()` on unvalidated status text.

## Plan

- allow only exact HTTP/1.0 and HTTP/1.1 versions;
- parse exactly three ASCII status digits and require 100–999;
- allow only HTAB, SP, visible ASCII, and obs-text in reason phrases;
- preserve missing-field defaults and safe custom fields;
- normalize invalid present status codes to 500;
- regenerate missing/unsafe phrases for a valid code;
- add task-level boundary tests and a real-server injection regression.

## Compatibility

Normal responses, HTTP/1.0, valid extension codes, safe custom phrases, and empty phrases are preserved. Malformed/injecting fields now produce a valid safe start line.

## Validation

- pre-fix real socket: emitted forged `X-Injected: yes` before normal headers;
- post-fix real socket: `HTTP/1.1 200 OK` followed directly by normal headers;
- new normalization test fails completely against the old implementation;
- focused unit tests: 11/11 passed;
- real-server header/framing test: 1/1 passed;
- strict C++11 production and C++14 unit/integration compilation with `-Werror`;
- focused ASan + UBSan with leak detection: 12/12 passed;
- full CTest suite: 38/38 passed;
- cached `git diff --check`.

Spec: #371
