### PR TITLE
fix(request): make typed accessors non-throwing

### DIFF
--- a/src/core/HttpMsg.h
+++ b/src/core/HttpMsg.h
@@ -4,9 +4,14 @@
 #include "workflow/HttpMessage.h"
 #include "workflow/WFTaskFactory.h"
 
+#include <cerrno>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
 #include <fcntl.h>
-#include <unordered_map>
+#include <limits>
 #include <memory>
+#include <unordered_map>
 
 #include "StringPiece.h"
 #include "HttpDef.h"
@@ -29,6 +34,77 @@ namespace wfrest
 
 struct ReqData;
 class MySQL;
+
+namespace detail
+{
+
+inline int parse_int_route_parameter(const std::string &text)
+{
+    const char *begin = text.c_str();
+    char *end = nullptr;
+    const int saved_errno = errno;
+    errno = 0;
+    const long parsed = std::strtol(begin, &end, 10);
+    const int parse_errno = errno;
+    errno = saved_errno;
+
+    if (end == begin || end != begin + text.size() || parse_errno != 0 ||
+        parsed < std::numeric_limits<int>::min() ||
+        parsed > std::numeric_limits<int>::max())
+    {
+        return 0;
+    }
+    return static_cast<int>(parsed);
+}
+
+inline size_t parse_size_route_parameter(const std::string &text)
+{
+    const char *begin = text.c_str();
+    const char *limit = begin + text.size();
+    const char *sign = begin;
+    while (sign != limit &&
+           std::isspace(static_cast<unsigned char>(*sign)) != 0)
+    {
+        ++sign;
+    }
+    if (sign != limit && *sign == '-')
+        return 0;
+
+    char *end = nullptr;
+    const int saved_errno = errno;
+    errno = 0;
+    const unsigned long long parsed = std::strtoull(begin, &end, 10);
+    const int parse_errno = errno;
+    errno = saved_errno;
+
+    if (end == begin || end != limit || parse_errno != 0 ||
+        parsed > static_cast<unsigned long long>(
+                     std::numeric_limits<size_t>::max()))
+    {
+        return 0;
+    }
+    return static_cast<size_t>(parsed);
+}
+
+inline double parse_double_route_parameter(const std::string &text)
+{
+    const char *begin = text.c_str();
+    char *end = nullptr;
+    const int saved_errno = errno;
+    errno = 0;
+    const double parsed = std::strtod(begin, &end);
+    const int parse_errno = errno;
+    errno = saved_errno;
+
+    if (end == begin || end != begin + text.size() || parse_errno != 0 ||
+        !std::isfinite(parsed))
+    {
+        return 0.0;
+    }
+    return parsed;
+}
+
+} // namespace detail
 
 class HttpReq : public protocol::HttpRequest, public Noncopyable
 {
@@ -74,7 +150,7 @@ public:
     { return route_full_path_; }
 
     std::string current_path() const
-    { return parsed_uri_.path; }
+    { return parsed_uri_.path == nullptr ? std::string() : parsed_uri_.path; }
 
     const std::map<std::string, std::string> &cookies() const;
 
@@ -140,7 +216,7 @@ template<>
 inline int HttpReq::param<int>(const std::string &key) const
 {
     if (route_params_.count(key))
-        return std::stoi(route_params_.at(key));
+        return detail::parse_int_route_parameter(route_params_.at(key));
     else
         return 0;
 }
@@ -149,7 +225,7 @@ template<>
 inline size_t HttpReq::param<size_t>(const std::string &key) const
 {
     if (route_params_.count(key))
-        return static_cast<size_t>(std::stoul(route_params_.at(key)));
+        return detail::parse_size_route_parameter(route_params_.at(key));
     else
         return 0;
 }
@@ -158,7 +234,7 @@ template<>
 inline double HttpReq::param<double>(const std::string &key) const
 {
     if (route_params_.count(key))
-        return std::stod(route_params_.at(key));
+        return detail::parse_double_route_parameter(route_params_.at(key));
     else
         return 0.0;
 }

--- a/test/HttpMsg_unittest.cc
+++ b/test/HttpMsg_unittest.cc
@@ -2,6 +2,7 @@
 #include <cerrno>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <new>
 #include <string>
 #include <gtest/gtest.h>
@@ -224,6 +225,90 @@ TEST(HttpReqMove, initializes_default_and_wrapped_requests)
     EXPECT_STREQ(wrapped->get_method(), "POST");
     EXPECT_STREQ(wrapped->get_request_uri(), "/wrapped");
     wrapped->~HttpReq();
+}
+
+TEST(HttpReqAccessors, converts_typed_params_without_exceptions)
+{
+    HttpReq request;
+    const std::string int_min =
+        std::to_string(std::numeric_limits<int>::min());
+    const std::string int_max =
+        std::to_string(std::numeric_limits<int>::max());
+    const std::string size_max =
+        std::to_string(std::numeric_limits<size_t>::max());
+    const std::string embedded("12\0tail", 7);
+    request.set_route_params({
+        {"int", " -42"},
+        {"int_min", int_min},
+        {"int_max", int_max},
+        {"size", "+17"},
+        {"size_max", size_max},
+        {"double", "1.25e2"},
+        {"empty", ""},
+        {"suffix", "12tail"},
+        {"trailing", "12 "},
+        {"overflow", "999999999999999999999999999999999"},
+        {"negative_size", " -1"},
+        {"size_overflow", size_max + "0"},
+        {"nan", "nan"},
+        {"infinity", "inf"},
+        {"double_overflow", "1e9999"},
+        {"double_underflow", "1e-9999"},
+        {"embedded", embedded}
+    });
+
+    errno = EDOM;
+    EXPECT_EQ(request.param<int>("int"), -42);
+    EXPECT_EQ(request.param<int>("int_min"),
+              std::numeric_limits<int>::min());
+    EXPECT_EQ(request.param<int>("int_max"),
+              std::numeric_limits<int>::max());
+    EXPECT_EQ(request.param<int>("missing"), 0);
+    EXPECT_EQ(request.param<int>("empty"), 0);
+    EXPECT_EQ(request.param<int>("suffix"), 0);
+    EXPECT_EQ(request.param<int>("trailing"), 0);
+    EXPECT_EQ(request.param<int>("overflow"), 0);
+    EXPECT_EQ(request.param<int>("embedded"), 0);
+    EXPECT_EQ(errno, EDOM);
+
+    errno = EAGAIN;
+    EXPECT_EQ(request.param<size_t>("size"), 17U);
+    EXPECT_EQ(request.param<size_t>("size_max"),
+              std::numeric_limits<size_t>::max());
+    EXPECT_EQ(request.param<size_t>("negative_size"), 0U);
+    EXPECT_EQ(request.param<size_t>("size_overflow"), 0U);
+    EXPECT_EQ(request.param<size_t>("embedded"), 0U);
+    EXPECT_EQ(errno, EAGAIN);
+
+    errno = ENOENT;
+    EXPECT_DOUBLE_EQ(request.param<double>("double"), 125.0);
+    EXPECT_DOUBLE_EQ(request.param<double>("suffix"), 0.0);
+    EXPECT_DOUBLE_EQ(request.param<double>("nan"), 0.0);
+    EXPECT_DOUBLE_EQ(request.param<double>("infinity"), 0.0);
+    EXPECT_DOUBLE_EQ(request.param<double>("double_overflow"), 0.0);
+    EXPECT_DOUBLE_EQ(request.param<double>("double_underflow"), 0.0);
+    EXPECT_DOUBLE_EQ(request.param<double>("embedded"), 0.0);
+    EXPECT_EQ(errno, ENOENT);
+}
+
+TEST(HttpReqAccessors, current_path_is_safe_across_move_states)
+{
+    HttpReq request;
+    EXPECT_TRUE(request.current_path().empty());
+
+    ParsedURI parsed;
+    ASSERT_EQ(URIParser::parse("http://example.test/path?query=1", parsed), 0);
+    request.set_parsed_uri(std::move(parsed));
+    EXPECT_EQ(request.current_path(), "/path");
+
+    HttpReq moved(std::move(request));
+    EXPECT_EQ(moved.current_path(), "/path");
+    EXPECT_TRUE(request.current_path().empty());
+
+    HttpReq assigned;
+    assigned = std::move(moved);
+    EXPECT_EQ(assigned.current_path(), "/path");
+    EXPECT_TRUE(moved.current_path().empty());
 }
 
 TEST(HttpReqMove, transfers_all_derived_state)

--- a/test/HttpServer/param_test.cc
+++ b/test/HttpServer/param_test.cc
@@ -22,7 +22,7 @@ WFHttpTask *create_http_task(const std::string &path)
 TEST(HttpServer, param)
 {
     HttpServer svr;
-    WFFacilities::WaitGroup wait_group(3);
+    WFFacilities::WaitGroup wait_group(5);
 
     svr.GET("/user/{name}/match*", [](const HttpReq *req, HttpResp *resp)
     {
@@ -40,6 +40,14 @@ TEST(HttpServer, param)
         json["message"] = req->query("message");
         json["expr"] = req->query("expr");
         json["bad"] = req->query("bad");
+        resp->Json(json);
+    });
+    svr.GET("/number/{value}", [](const HttpReq *req, HttpResp *resp)
+    {
+        Json json;
+        json["int"] = req->param<int>("value");
+        json["size"] = req->param<size_t>("value");
+        json["double"] = req->param<double>("value");
         resp->Json(json);
     });
     EXPECT_TRUE(svr.start("127.0.0.1", 8888) == 0) << "http server start failed";
@@ -88,6 +96,38 @@ TEST(HttpServer, param)
         EXPECT_EQ(json["message"].get<std::string>(), "hello world");
         EXPECT_EQ(json["expr"].get<std::string>(), "a&b=c");
         EXPECT_EQ(json["bad"].get<std::string>(), "%ZZ");
+        wait_group.done();
+    });
+
+    WFHttpTask *invalid_number = create_http_task("/number/not-a-number");
+    series->push_back(invalid_number);
+    invalid_number->set_callback([&wait_group](WFHttpTask *task)
+    {
+        EXPECT_EQ(task->get_state(), WFT_STATE_SUCCESS);
+        const void *body = nullptr;
+        size_t body_len = 0;
+        task->get_resp()->get_parsed_body(&body, &body_len);
+        Json json = Json::parse(
+            std::string(static_cast<const char *>(body), body_len));
+        EXPECT_EQ(json["int"].get<int>(), 0);
+        EXPECT_EQ(json["size"].get<size_t>(), 0U);
+        EXPECT_DOUBLE_EQ(json["double"].get<double>(), 0.0);
+        wait_group.done();
+    });
+
+    WFHttpTask *valid_number = create_http_task("/number/42");
+    series->push_back(valid_number);
+    valid_number->set_callback([&wait_group](WFHttpTask *task)
+    {
+        EXPECT_EQ(task->get_state(), WFT_STATE_SUCCESS);
+        const void *body = nullptr;
+        size_t body_len = 0;
+        task->get_resp()->get_parsed_body(&body, &body_len);
+        Json json = Json::parse(
+            std::string(static_cast<const char *>(body), body_len));
+        EXPECT_EQ(json["int"].get<int>(), 42);
+        EXPECT_EQ(json["size"].get<size_t>(), 42U);
+        EXPECT_DOUBLE_EQ(json["double"].get<double>(), 42.0);
         wait_group.done();
     });
     series->start();


### PR DESCRIPTION
Closes #373

## Why

Typed route parameters used throwing `stoi/stoul/stod` even though WFRest is built with `-fno-exceptions`, and `current_path()` constructed a string from a nullable parsed-path pointer. Independent probes terminated with exit 134 for malformed typed input and a default request.

## Plan

- replace throwing conversions with exact C++11 C-library parsing;
- require complete consumption and destination-range validity;
- reject negative sizes, non-finite doubles, range errors, and embedded-NUL suffixes;
- restore caller `errno` after conversion;
- retain zero defaults for missing/invalid values;
- return an empty path for unparsed and moved-from requests;
- cover unit boundaries, moves, and real-server malformed route input.

## Compatibility

Signatures and missing-value defaults are unchanged. Valid numeric parameters still convert normally. Prefix-only, out-of-range, negative-size, and non-finite inputs now return zero instead of throwing or producing surprising values.

## Validation

- pre-fix probes: typed parameter and default current path both exited 134;
- post-fix probes: `typed-param=0` and `current-path-size=0`;
- focused accessor/move tests: 6/6 passed;
- real-server parameter test: 1/1 passed with malformed and valid segments;
- strict C++11 production and C++14 unit/integration `-Werror -fno-exceptions` compilation;
- focused ASan + UBSan with leak detection: 14/14 passed;
- full CTest suite: 38/38 passed;
- cached `git diff --check`.

Spec: #374
