### PR TITLE
fix(request): own temporary query fallbacks

### DIFF
--- a/src/core/HttpMsg.cc
+++ b/src/core/HttpMsg.cc
@@ -650,10 +650,14 @@ const std::string &HttpReq::query(const std::string &key) const
 
 const std::string &HttpReq::default_query(const std::string &key, const std::string &default_val) const
 {
-    if (query_params_.count(key))
-        return query_params_.at(key);
-    else
-        return default_val;
+    auto it = query_params_.find(key);
+    return it == query_params_.end() ? default_val : it->second;
+}
+
+std::string HttpReq::default_query(const std::string &key, std::string &&default_val) const
+{
+    auto it = query_params_.find(key);
+    return it == query_params_.end() ? std::move(default_val) : it->second;
 }
 
 bool HttpReq::has_query(const std::string &key) const

--- a/src/core/HttpMsg.h
+++ b/src/core/HttpMsg.h
@@ -12,6 +12,7 @@
 #include <limits>
 #include <memory>
 #include <unordered_map>
+#include <utility>
 
 #include "StringPiece.h"
 #include "HttpDef.h"
@@ -136,6 +137,9 @@ public:
 
     const std::string &default_query(const std::string &key,
                                      const std::string &default_val) const;
+
+    std::string default_query(const std::string &key,
+                              std::string &&default_val) const;
 
     const std::map<std::string, std::string> &query_list() const
     { return query_params_; }

--- a/test/HttpMsg_unittest.cc
+++ b/test/HttpMsg_unittest.cc
@@ -5,6 +5,8 @@
 #include <limits>
 #include <new>
 #include <string>
+#include <type_traits>
+#include <utility>
 #include <gtest/gtest.h>
 #include "wfrest/HttpMsg.h"
 #include "wfrest/HttpServerTask.h"
@@ -76,6 +78,23 @@ private:
 };
 
 } // namespace
+
+static_assert(std::is_same<
+    decltype(std::declval<const HttpReq&>().default_query(
+        std::declval<const std::string&>(), std::declval<std::string&>())),
+    const std::string&>::value,
+    "lvalue query fallbacks must keep reference semantics");
+
+static_assert(std::is_same<
+    decltype(std::declval<const HttpReq&>().default_query(
+        std::declval<const std::string&>(), std::declval<std::string&&>())),
+    std::string>::value,
+    "temporary query fallbacks must return owned strings");
+
+static_assert(std::is_same<
+    decltype(std::declval<const HttpReq&>().default_query("key", "fallback")),
+    std::string>::value,
+    "literal query fallbacks must return owned strings");
 
 TEST(HttpServerTaskPeer, rejects_unavailable_or_truncated_addresses)
 {
@@ -289,6 +308,37 @@ TEST(HttpReqAccessors, converts_typed_params_without_exceptions)
     EXPECT_DOUBLE_EQ(request.param<double>("double_underflow"), 0.0);
     EXPECT_DOUBLE_EQ(request.param<double>("embedded"), 0.0);
     EXPECT_EQ(errno, ENOENT);
+}
+
+TEST(HttpReqAccessors, owns_temporary_default_query_fallbacks)
+{
+    HttpReq request;
+    request.set_query_params({{"present", "stored"}});
+
+    std::string fallback = "caller-owned";
+    const std::string& missing_lvalue =
+        request.default_query("missing", fallback);
+    EXPECT_EQ(&missing_lvalue, &fallback);
+
+    const std::string& present_lvalue =
+        request.default_query("present", fallback);
+    EXPECT_EQ(&present_lvalue, &request.query("present"));
+    EXPECT_EQ(present_lvalue, "stored");
+
+    const std::string& missing_temporary = request.default_query(
+        "missing", std::string(4096, 'x'));
+    EXPECT_EQ(missing_temporary.size(), 4096U);
+    EXPECT_EQ(missing_temporary.front(), 'x');
+    EXPECT_EQ(missing_temporary.back(), 'x');
+
+    const std::string& missing_literal =
+        request.default_query("missing", "literal");
+    EXPECT_EQ(missing_literal, "literal");
+
+    std::string present_owned = request.default_query(
+        "present", std::string("unused"));
+    request.set_query_params({{"present", "changed"}});
+    EXPECT_EQ(present_owned, "stored");
 }
 
 TEST(HttpReqAccessors, current_path_is_safe_across_move_states)


### PR DESCRIPTION
Closes #376

## Why

HttpReq::default_query() returned a const-reference fallback directly. A literal or temporary fallback is destroyed at the end of the call expression, so a retained result dangles. The pre-fix AddressSanitizer probe reports stack-use-after-scope in std::string::size().

Changing the old return type would risk ABI mismatch, because ordinary C++ mangling does not encode return types.

## Plan

- retain the existing const-reference overload for lvalue fallbacks;
- add a by-value rvalue overload for temporary and literal fallbacks;
- move a missing fallback and copy a present query value into the owning result;
- use one query-map lookup in each overload;
- lock overload selection with compile-time type assertions;
- cover hit, miss, reference identity, ownership, and lifetime extension.

## Compatibility

Lvalue calls retain the original symbol, return type, zero-copy behavior, and reference identity. Rvalue and literal calls intentionally select the new owning overload. Query selection is unchanged; a present value is copied only for the temporary-only overload.

## Validation

- pre-fix lifetime probe: ASan stack-use-after-scope;
- post-fix identical probe: output 4096 with no ASan/UBSan finding;
- compile-time checks for lvalue, temporary, and literal result types;
- strict production and test compilation with -Werror -fno-exceptions;
- focused ASan + UBSan with leak and stack-lifetime detection: 14/14 passed;
- full CTest suite with the system runtime: 38/38 passed;
- symbol inspection confirms both the retained const-reference overload and the new rvalue overload;
- git diff --check.

Spec: #377