### PR TITLE
fix(request): refresh derived header caches

### DIFF
--- a/src/core/HttpMsg.cc
+++ b/src/core/HttpMsg.cc
@@ -704,6 +704,7 @@ void HttpReq::fill_header_map()
 {
     http_header_cursor_t cursor;
     struct protocol::HttpMessageHeader header;
+    HeaderMap refreshed_headers;
 
     http_header_cursor_init(&cursor, this->get_parser());
     while (http_header_cursor_next(&header.name, &header.name_len,
@@ -712,10 +713,14 @@ void HttpReq::fill_header_map()
     {
         std::string key(static_cast<const char *>(header.name), header.name_len);
 
-        headers_[key].emplace_back(static_cast<const char *>(header.value), header.value_len);
+        refreshed_headers[key].emplace_back(
+            static_cast<const char *>(header.value), header.value_len);
     }
 
     http_header_cursor_deinit(&cursor);
+    headers_.swap(refreshed_headers);
+    cookies_.clear();
+    cookies_parsed_ = false;
 }
 
 const std::map<std::string, std::string> &HttpReq::cookies() const

--- a/test/HttpMsg_unittest.cc
+++ b/test/HttpMsg_unittest.cc
@@ -361,6 +361,39 @@ TEST(HttpReqAccessors, current_path_is_safe_across_move_states)
     EXPECT_TRUE(moved.current_path().empty());
 }
 
+TEST(HttpReqHeaders, refreshes_headers_and_cookie_cache)
+{
+    HttpReq request;
+    EXPECT_TRUE(request.cookies().empty());
+
+    ASSERT_TRUE(request.add_header_pair("X-Trace", "old"));
+    ASSERT_TRUE(request.add_header_pair(
+        "Cookie", "session=old; removed=value"));
+    request.fill_header_map();
+
+    EXPECT_EQ(request.header("x-trace"), "old");
+    EXPECT_EQ(request.cookie("session"), "old");
+    EXPECT_EQ(request.cookie("removed"), "value");
+
+    ASSERT_TRUE(request.set_header_pair("X-Trace", "new"));
+    ASSERT_TRUE(request.set_header_pair(
+        "Cookie", "session=new; added=value"));
+    request.fill_header_map();
+
+    EXPECT_EQ(request.header("X-TRACE"), "new");
+    EXPECT_EQ(request.header("Cookie"), "session=new; added=value");
+    EXPECT_EQ(request.cookie("session"), "new");
+    EXPECT_TRUE(request.cookie("removed").empty());
+    EXPECT_EQ(request.cookie("added"), "value");
+    EXPECT_EQ(request.cookies().size(), 2U);
+
+    request.fill_header_map();
+    EXPECT_EQ(request.header("X-Trace"), "new");
+    EXPECT_EQ(request.cookie("session"), "new");
+    EXPECT_EQ(request.cookie("added"), "value");
+    EXPECT_EQ(request.cookies().size(), 2U);
+}
+
 TEST(HttpReqMove, transfers_all_derived_state)
 {
     HttpReq source;


### PR DESCRIPTION
Closes #379

## Why

fill_header_map() appended parser fields to an existing map and left the lazy cookie cache marked parsed. Replacing an underlying Cookie header and refilling therefore kept exposing the old header and cookie. The pre-fix probe prints session=old old on both lines.

## Plan

- scan current parser fields into a fresh local HeaderMap;
- swap the completed snapshot into headers_ after cursor cleanup;
- clear cookies_ and reset cookies_parsed_ after each refresh;
- preserve per-snapshot ordering and case-insensitive lookup;
- cover access before fill, replacement/refill, removed cookie state, and unchanged idempotence.

## Compatibility

The first-fill server path is unchanged. Repeated calls intentionally replace historical cached data instead of appending it. Public signatures and object layout are unchanged; callers must reacquire references after an explicit refresh.

## Validation

- pre-fix probe after replacement: session=old old;
- post-fix identical probe: session=new new;
- focused request header/accessor/move tests: 8/8 passed;
- strict production and unit compilation with -Werror -fno-exceptions;
- focused ASan + UBSan with leak and stack-lifetime detection: 15/15 passed;
- full CTest suite using the system runtime: 38/38 passed;
- git diff --check.

Spec: #380