### PR TITLE
fix(request): track derived cache state

### DIFF
--- a/src/core/HttpMsg.cc
+++ b/src/core/HttpMsg.cc
@@ -296,6 +296,10 @@ struct ReqData
     std::map<std::string, std::string> form_kv;
     Form form;
     Json json;
+    bool body_loaded = false;
+    bool form_kv_attempted = false;
+    bool form_attempted = false;
+    bool json_attempted = false;
 };
 
 struct ProxyCtx
@@ -570,7 +574,7 @@ HttpReq::~HttpReq() = default;
 
 std::string &HttpReq::body() const
 {
-    if (req_data_->body.empty())
+    if (!req_data_->body_loaded)
     {
         std::string content = protocol::HttpUtil::decode_chunked_body(this);
 
@@ -588,34 +592,39 @@ std::string &HttpReq::body() const
         {
             req_data_->body = std::move(content);
         }
+        req_data_->body_loaded = true;
     }
     return req_data_->body;
 }
 
 std::map<std::string, std::string> &HttpReq::form_kv() const
 {
-    if (content_type_ == APPLICATION_URLENCODED && req_data_->form_kv.empty())
+    if (content_type_ == APPLICATION_URLENCODED &&
+        !req_data_->form_kv_attempted)
     {
         StringPiece body_piece(this->body());
         req_data_->form_kv = Urlencode::parse_post_kv(body_piece);
+        req_data_->form_kv_attempted = true;
     }
     return req_data_->form_kv;
 }
 
 Form &HttpReq::form() const
 {
-    if (content_type_ == MULTIPART_FORM_DATA && req_data_->form.empty())
+    if (content_type_ == MULTIPART_FORM_DATA &&
+        !req_data_->form_attempted)
     {
         StringPiece body_piece(this->body());
 
         req_data_->form = multi_part_.parse_multipart(body_piece);
+        req_data_->form_attempted = true;
     }
     return req_data_->form;
 }
 
 wfrest::Json &HttpReq::json() const
 {
-    if (content_type_ == APPLICATION_JSON && req_data_->json.empty())
+    if (content_type_ == APPLICATION_JSON && !req_data_->json_attempted)
     {
         const std::string &body_content = this->body();
         Json tmp = Json::parse(body_content);
@@ -623,6 +632,7 @@ wfrest::Json &HttpReq::json() const
         {
             req_data_->json = std::move(tmp);
         }
+        req_data_->json_attempted = true;
     }
     return req_data_->json;
 }

--- a/test/HttpMsg_unittest.cc
+++ b/test/HttpMsg_unittest.cc
@@ -77,6 +77,38 @@ private:
     bool initialized_;
 };
 
+class RequestParseHarness : public HttpReq
+{
+public:
+    bool parse(const std::string& wire)
+    {
+        size_t size = wire.size();
+        return this->append(wire.data(), &size) == 1 && size == wire.size();
+    }
+};
+
+std::string request_wire(const std::string& content_type,
+                         const std::string& body)
+{
+    std::string wire = "POST / HTTP/1.1\r\nHost: example.test\r\n";
+    if (!content_type.empty())
+        wire += "Content-Type: " + content_type + "\r\n";
+    wire += "Content-Length: " + std::to_string(body.size()) +
+            "\r\n\r\n" + body;
+    return wire;
+}
+
+bool prepare_request(RequestParseHarness *request,
+                     const std::string& content_type,
+                     const std::string& body)
+{
+    if (!request->parse(request_wire(content_type, body)))
+        return false;
+    request->fill_header_map();
+    request->fill_content_type();
+    return true;
+}
+
 } // namespace
 
 static_assert(std::is_same<
@@ -392,6 +424,69 @@ TEST(HttpReqHeaders, refreshes_headers_and_cookie_cache)
     EXPECT_EQ(request.cookie("session"), "new");
     EXPECT_EQ(request.cookie("added"), "value");
     EXPECT_EQ(request.cookies().size(), 2U);
+}
+
+TEST(HttpReqCaches, keeps_empty_and_mutated_results_loaded)
+{
+    RequestParseHarness plain;
+    ASSERT_TRUE(prepare_request(&plain, "text/plain", "original"));
+    EXPECT_EQ(plain.body(), "original");
+    plain.body().clear();
+    EXPECT_TRUE(plain.body().empty());
+
+    HttpReq moved(std::move(plain));
+    EXPECT_TRUE(moved.body().empty());
+
+    RequestParseHarness encoded;
+    ASSERT_TRUE(prepare_request(&encoded,
+                                "application/x-www-form-urlencoded",
+                                "key=value"));
+    ASSERT_EQ(encoded.form_kv().at("key"), "value");
+    encoded.form_kv().clear();
+    EXPECT_TRUE(encoded.form_kv().empty());
+
+    RequestParseHarness json;
+    ASSERT_TRUE(prepare_request(&json, "application/json", "{\"key\":1}"));
+    ASSERT_TRUE(json.json().has("key"));
+    json.json().clear();
+    EXPECT_FALSE(json.json().has("key"));
+
+    RequestParseHarness multipart;
+    ASSERT_TRUE(prepare_request(
+        &multipart, "multipart/form-data; boundary=abc",
+        "--abc\r\nContent-Disposition: form-data; name=item\r\n"
+        "\r\nvalue\r\n--abc--\r\n"));
+    ASSERT_EQ(multipart.form().at("item").second, "value");
+    multipart.form().clear();
+    EXPECT_TRUE(multipart.form().empty());
+}
+
+TEST(HttpReqCaches, caches_empty_and_failed_parse_attempts)
+{
+    RequestParseHarness empty_form;
+    ASSERT_TRUE(prepare_request(
+        &empty_form, "application/x-www-form-urlencoded", ""));
+    EXPECT_TRUE(empty_form.form_kv().empty());
+    empty_form.body() = "late=value";
+    EXPECT_TRUE(empty_form.form_kv().empty());
+
+    RequestParseHarness invalid_json;
+    ASSERT_TRUE(prepare_request(
+        &invalid_json, "application/json", "not-json"));
+    EXPECT_FALSE(invalid_json.json().has("late"));
+    invalid_json.body() = "{\"late\":true}";
+    EXPECT_FALSE(invalid_json.json().has("late"));
+
+    RequestParseHarness incomplete_multipart;
+    ASSERT_TRUE(prepare_request(
+        &incomplete_multipart, "multipart/form-data; boundary=abc",
+        "--abc\r\nContent-Disposition: form-data; name=item\r\n"
+        "\r\nincomplete"));
+    EXPECT_TRUE(incomplete_multipart.form().empty());
+    incomplete_multipart.body() =
+        "--abc\r\nContent-Disposition: form-data; name=item\r\n"
+        "\r\nlate\r\n--abc--\r\n";
+    EXPECT_TRUE(incomplete_multipart.form().empty());
 }
 
 TEST(HttpReqMove, transfers_all_derived_state)


### PR DESCRIPTION
Closes #382

## Why

Request body, URL-encoded form, multipart form, and JSON accessors used empty() as an unloaded sentinel. Empty/invalid inputs were repeatedly parsed, and clearing a returned mutable cache caused the original request data to reappear. A complete HTTP parser probe reproduced resurrection for all four caches.

## Plan

- add explicit body-loaded and parser-attempted flags to private ReqData;
- decode or attempt a matching parse once even when the result is empty/invalid;
- keep returned mutable objects authoritative after first access;
- preserve type gates and first-access behavior;
- carry all state through the existing unique_ptr move;
- cover parsed requests, mutation, failed attempts, and move state.

## Compatibility

Public symbols, signatures, sizeof(HttpReq), and first-access results are unchanged. Empty caches now behave consistently with non-empty caches. Clearing a returned object no longer acts as an undocumented reparse command.

## Validation

- pre-fix four-cache probe: body=original, form-size=1, json-key=1, multipart-size=1 after clear;
- post-fix identical probe: empty body, form-size=0, json-key=0, multipart-size=0;
- focused request cache/header/move tests: 7/7 passed;
- strict production and unit compilation with -Werror -fno-exceptions;
- focused ASan + UBSan with leak and stack-lifetime detection: 17/17 passed;
- full CTest suite using the system runtime: 38/38 passed;
- git diff --check.

Spec: #383